### PR TITLE
OP-1468: fix dialog when export fails

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -32,7 +32,6 @@ const BENEFIT_PLAN_FULL_PROJECTION = () => [
   'beneficiaryDataSchema',
   'jsonExt',
   'institution',
-  'hasPaymentPlans',
   'version',
   'userUpdated {username}',
 ];

--- a/src/components/BenefitPackageMembersSearcher.js
+++ b/src/components/BenefitPackageMembersSearcher.js
@@ -15,6 +15,7 @@ import {
   Button,
   DialogActions,
   DialogTitle,
+  DialogContent,
 } from '@material-ui/core';
 import VisibilityIcon from '@material-ui/icons/Visibility';
 import HistoryIcon from '@material-ui/icons/History';
@@ -157,7 +158,9 @@ function BenefitPackageMembersSearcher({
   const [appliedFiltersRowStructure, setAppliedFiltersRowStructure] = useState([CLEARED_STATE_FILTER]);
 
   useEffect(() => {
-    setFailedExport(true);
+    if (errorMembersExport) {
+      setFailedExport(true);
+    }
   }, [errorMembersExport]);
 
   useEffect(() => {
@@ -165,6 +168,8 @@ function BenefitPackageMembersSearcher({
       downloadExport(membersExport, `${formatMessage(intl, 'socialProtection', 'export.filename')}.csv`)();
       dispatch(clearIndividualExportRef());
     }
+
+    return setFailedExport(false);
   }, [membersExport]);
 
   useEffect(() => {
@@ -225,14 +230,18 @@ function BenefitPackageMembersSearcher({
         applyNumberCircle={applyNumberCircle}
       />
       {failedExport && (
-      <Dialog fullWidth maxWidth="sm">
-        <DialogTitle>{errorMembersExport}</DialogTitle>
-        <DialogActions>
-          <Button onClick={setFailedExport(false)} variant="contained">
-            {formatMessage(intl, 'socialProtection', 'ok')}
-          </Button>
-        </DialogActions>
-      </Dialog>
+        <Dialog open={failedExport} fullWidth maxWidth="sm">
+          <DialogTitle>{errorMembersExport?.message}</DialogTitle>
+          <DialogContent>
+            <strong>{`${errorMembersExport?.code}: `}</strong>
+            {errorMembersExport?.detail}
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={() => setFailedExport(false)} color="primary" variant="contained">
+              {formatMessage(intl, 'socialProtection', 'ok')}
+            </Button>
+          </DialogActions>
+        </Dialog>
       )}
     </>
   );

--- a/src/components/BenefitPlanBeneficiariesSearcher.js
+++ b/src/components/BenefitPlanBeneficiariesSearcher.js
@@ -20,6 +20,7 @@ import {
   DialogTitle,
   IconButton,
   Tooltip,
+  DialogContent,
 } from '@material-ui/core';
 import PreviewIcon from '@material-ui/icons/ListAlt';
 import {
@@ -172,7 +173,9 @@ function BenefitPlanBeneficiariesSearcher({
   const [appliedFiltersRowStructure, setAppliedFiltersRowStructure] = useState([CLEARED_STATE_FILTER]);
 
   useEffect(() => {
-    setFailedExport(true);
+    if (errorBeneficiaryExport) {
+      setFailedExport(true);
+    }
   }, [errorBeneficiaryExport]);
 
   useEffect(() => {
@@ -183,6 +186,8 @@ function BenefitPlanBeneficiariesSearcher({
       )();
       clearBeneficiaryExport();
     }
+
+    return setFailedExport(false);
   }, [beneficiaryExport]);
 
   const beneficiaryFilter = (props) => (
@@ -253,14 +258,17 @@ function BenefitPlanBeneficiariesSearcher({
         rowLocked={isRowDisabled}
       />
       {failedExport && (
-      <Dialog fullWidth maxWidth="sm">
-        <DialogTitle>{errorBeneficiaryExport}</DialogTitle>
-        <DialogActions>
-          <Button onClick={setFailedExport(false)} variant="contained">
-            {formatMessage(intl, 'socialProtection', 'ok')}
-          </Button>
-        </DialogActions>
-      </Dialog>
+        <Dialog open={failedExport} fullWidth maxWidth="sm">
+          <DialogTitle>{errorBeneficiaryExport?.message}</DialogTitle>
+          <DialogContent>
+            <strong>{`${errorBeneficiaryExport?.code}: `}</strong>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={() => setFailedExport(false)} color="primary" variant="contained">
+              {formatMessage(intl, 'socialProtection', 'ok')}
+            </Button>
+          </DialogActions>
+        </Dialog>
       )}
     </div>
     )

--- a/src/components/BenefitPlanGroupBeneficiariesSearcher.js
+++ b/src/components/BenefitPlanGroupBeneficiariesSearcher.js
@@ -19,6 +19,7 @@ import {
   DialogTitle,
   IconButton,
   Tooltip,
+  DialogContent,
 } from '@material-ui/core';
 import PreviewIcon from '@material-ui/icons/ListAlt';
 import {
@@ -156,7 +157,9 @@ function BenefitPlanGroupBeneficiariesSearcher({
     updatedGroupBeneficiaries.some((item) => item.id === groupBeneficiary.id));
 
   useEffect(() => {
-    setFailedExport(true);
+    if (errorGroupBeneficiaryExport) {
+      setFailedExport(true);
+    }
   }, [errorGroupBeneficiaryExport]);
 
   useEffect(() => {
@@ -167,6 +170,8 @@ function BenefitPlanGroupBeneficiariesSearcher({
       )();
       clearGroupBeneficiaryExport();
     }
+
+    return setFailedExport(false);
   }, [groupBeneficiaryExport]);
 
   const groupBeneficiaryFilter = (props) => (
@@ -218,14 +223,18 @@ function BenefitPlanGroupBeneficiariesSearcher({
         rowLocked={isRowDisabled}
       />
       {failedExport && (
-      <Dialog fullWidth maxWidth="sm">
-        <DialogTitle>{errorGroupBeneficiaryExport}</DialogTitle>
-        <DialogActions>
-          <Button onClick={setFailedExport(false)} variant="contained">
-            {formatMessage(intl, 'socialProtection', 'ok')}
-          </Button>
-        </DialogActions>
-      </Dialog>
+        <Dialog open={failedExport} fullWidth maxWidth="sm">
+          <DialogTitle>{errorGroupBeneficiaryExport?.message}</DialogTitle>
+          <DialogContent>
+            <strong>{`${errorGroupBeneficiaryExport?.code}: `}</strong>
+            {errorGroupBeneficiaryExport?.detail}
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={() => setFailedExport(false)} color="primary" variant="contained">
+              {formatMessage(intl, 'socialProtection', 'ok')}
+            </Button>
+          </DialogActions>
+        </Dialog>
       )}
     </div>
     )


### PR DESCRIPTION
[OP-1468](https://openimis.atlassian.net/browse/OP-1468)

Changes:
- Improve error handling for export failures. Currently, a pop-up message is displayed from the backend.

[OP-1468]: https://openimis.atlassian.net/browse/OP-1468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ