### PR TITLE
Status linked eligibility criteria

### DIFF
--- a/src/components/BenefitPlanBeneficiariesSearcher.js
+++ b/src/components/BenefitPlanBeneficiariesSearcher.js
@@ -30,8 +30,6 @@ import {
   DEFAULT_PAGE_SIZE,
   RIGHT_BENEFICIARY_SEARCH,
   ROWS_PER_PAGE_OPTIONS,
-  MODULE_NAME,
-  BENEFIT_PLAN_LABEL,
   RIGHT_BENEFICIARY_UPDATE,
 } from '../constants';
 import BenefitPlanBeneficiariesFilter from './BenefitPlanBeneficiariesFilter';

--- a/src/components/BenefitPlanBeneficiariesSearcher.js
+++ b/src/components/BenefitPlanBeneficiariesSearcher.js
@@ -201,6 +201,8 @@ function BenefitPlanBeneficiariesSearcher({
     />
   );
 
+  const additionalParams = benefitPlan ? { benefitPlan: `${benefitPlan.id}` } : null;
+
   useEffect(() => {
     // refresh when appliedCustomFilters is changed
   }, [appliedCustomFilters]);
@@ -247,8 +249,9 @@ function BenefitPlanBeneficiariesSearcher({
         cacheTabName={`${benefitPlan?.id}-${status}`}
         isCustomFiltering
         objectForCustomFiltering={benefitPlan}
-        moduleName={MODULE_NAME}
-        objectType={BENEFIT_PLAN_LABEL}
+        moduleName="individual"
+        objectType="Individual"
+        additionalCustomFilterParams={additionalParams}
         appliedCustomFilters={appliedCustomFilters}
         setAppliedCustomFilters={setAppliedCustomFilters}
         appliedFiltersRowStructure={appliedFiltersRowStructure}

--- a/src/components/BenefitPlanEligibilityCriteriaPanel.js
+++ b/src/components/BenefitPlanEligibilityCriteriaPanel.js
@@ -8,7 +8,11 @@ import AddCircle from '@material-ui/icons/Add';
 import {
   Button, Divider, Grid, Paper, Typography,
 } from '@material-ui/core';
-import { CLEARED_STATE_FILTER, BENEFICIARY_STATUS } from '../constants';
+import {
+  CLEARED_STATE_FILTER,
+  BENEFICIARY_STATUS,
+  DEFAULT_BENEFICIARY_STATUS,
+} from '../constants';
 import { isBase64Encoded } from '../util/advanced-criteria-utils';
 
 const useStyles = makeStyles((theme) => ({
@@ -35,7 +39,6 @@ function BenefitPlanEligibilityCriteriaPanel({
   const { formatMessage, formatMessageWithValues } = useTranslations('socialProtection', modulesManager);
   const customFilters = useSelector((state) => state.core.customFilters);
   const [filters, setFilters] = useState([]);
-  const defaultFilterStatus = 'POTENTIAL';
 
   const status = Object.values(BENEFICIARY_STATUS).find((value) => (
     activeTab.toUpperCase().includes(value)
@@ -50,7 +53,7 @@ function BenefitPlanEligibilityCriteriaPanel({
     // For backward compatibility POTENTIAL status take on the old filters
     let criteria = jsonData?.advanced_criteria || {};
     if (Array.isArray(criteria)) {
-      criteria = { [defaultFilterStatus]: criteria };
+      criteria = { [DEFAULT_BENEFICIARY_STATUS]: criteria };
     }
 
     return criteria[status] || [];
@@ -105,8 +108,8 @@ function BenefitPlanEligibilityCriteriaPanel({
       const jsonData = JSON.parse(jsonExt);
       let advancedCriteria = jsonData?.advanced_criteria || {};
       // migrate old advanced_criteria
-      if (Array.isArray(jsonData?.advanced_criteria)) {
-        advancedCriteria = { [defaultFilterStatus]: jsonData?.advanced_criteria };
+      if (Array.isArray(advancedCriteria)) {
+        advancedCriteria = { [DEFAULT_BENEFICIARY_STATUS]: jsonData?.advanced_criteria };
       }
       const editedAdvancedCriteria = { ...advancedCriteria, [status]: filters };
       const json = { ...jsonData, advanced_criteria: editedAdvancedCriteria };

--- a/src/components/BenefitPlanEligibilityCriteriaPanel.js
+++ b/src/components/BenefitPlanEligibilityCriteriaPanel.js
@@ -8,7 +8,7 @@ import AddCircle from '@material-ui/icons/Add';
 import {
   Button, Divider, Grid, Paper, Typography,
 } from '@material-ui/core';
-import { CLEARED_STATE_FILTER } from '../constants';
+import { CLEARED_STATE_FILTER, BENEFICIARY_STATUS } from '../constants';
 import { isBase64Encoded } from '../util/advanced-criteria-utils';
 
 const useStyles = makeStyles((theme) => ({
@@ -23,6 +23,7 @@ function BenefitPlanEligibilityCriteriaPanel({
   edited,
   benefitPlan,
   onEditedChanged,
+  activeTab,
 }) {
   const classes = useStyles();
   const dispatch = useDispatch();
@@ -31,9 +32,12 @@ function BenefitPlanEligibilityCriteriaPanel({
   const moduleFilterName = 'individual';
   const objectFilterType = 'Individual';
   const modulesManager = useModulesManager();
-  const { formatMessage } = useTranslations('socialProtection', modulesManager);
+  const { formatMessage, formatMessageWithValues } = useTranslations('socialProtection', modulesManager);
   const customFilters = useSelector((state) => state.core.customFilters);
   const [filters, setFilters] = useState([]);
+  const show = Object.values(BENEFICIARY_STATUS).some((value) => (
+    activeTab.toUpperCase().includes(value)
+  ));
 
   const getAdvancedCriteria = () => {
     const { jsonExt } = benefitPlan ?? {};
@@ -106,12 +110,17 @@ function BenefitPlanEligibilityCriteriaPanel({
     }
   }, [filters]);
 
+  const beneficiaryStatus = formatMessage(`benefitPlan.${activeTab.replace('Tab', '')}.label`);
+
   return (
+    show && (
     <Paper className={classes.paper}>
       <Grid container alignItems="center" direction="row" className={classes.paperHeader}>
         <Grid item xs={12}>
           <Typography variant="h6" className={classes.tableTitle}>
-            {formatMessage('benefitPlan.BenefitPlanEligibilityCriteriaPanel.title')}
+            {formatMessageWithValues('benefitPlan.BenefitPlanEligibilityCriteriaPanel.title', {
+              beneficiaryStatus,
+            })}
           </Typography>
         </Grid>
         <Grid item xs={12}>
@@ -169,6 +178,7 @@ function BenefitPlanEligibilityCriteriaPanel({
         </Grid>
       </Grid>
     </Paper>
+    )
   );
 }
 

--- a/src/components/BenefitPlanGroupBeneficiariesSearcher.js
+++ b/src/components/BenefitPlanGroupBeneficiariesSearcher.js
@@ -31,13 +31,10 @@ import {
   RIGHT_BENEFICIARY_UPDATE,
   ROWS_PER_PAGE_OPTIONS,
   CLEARED_STATE_FILTER,
-  BENEFIT_PLAN_LABEL,
-  MODULE_NAME,
 } from '../constants';
 import BenefitPlanGroupBeneficiariesFilter from './BenefitPlanGroupBeneficiariesFilter';
 import BeneficiaryStatusPicker from '../pickers/BeneficiaryStatusPicker';
 import { applyNumberCircle } from '../util/searcher-utils';
-
 
 function BenefitPlanGroupBeneficiariesSearcher({
   rights,

--- a/src/components/BenefitPlanGroupBeneficiariesSearcher.js
+++ b/src/components/BenefitPlanGroupBeneficiariesSearcher.js
@@ -191,6 +191,8 @@ function BenefitPlanGroupBeneficiariesSearcher({
     />
   );
 
+  const additionalParams = benefitPlan ? { benefitPlan: `${benefitPlan.id}` } : null;
+
   useEffect(() => {
     // refresh when appliedCustomFilters is changed
   }, [appliedCustomFilters]);
@@ -233,8 +235,9 @@ function BenefitPlanGroupBeneficiariesSearcher({
         cacheTabName={`${benefitPlan?.id}-${status}`}
         isCustomFiltering
         objectForCustomFiltering={benefitPlan}
-        moduleName={MODULE_NAME}
-        objectType={BENEFIT_PLAN_LABEL}
+        moduleName="individual"
+        objectType="Individual"
+        additionalCustomFilterParams={additionalParams}
         appliedCustomFilters={appliedCustomFilters}
         setAppliedCustomFilters={setAppliedCustomFilters}
         appliedFiltersRowStructure={appliedFiltersRowStructure}

--- a/src/components/BenefitPlanTabPanel.js
+++ b/src/components/BenefitPlanTabPanel.js
@@ -38,7 +38,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 function BenefitPlanTabPanel({
-  intl, rights, benefitPlan, setConfirmedAction,
+  intl, rights, benefitPlan, setConfirmedAction, onActiveTabChange,
 }) {
   const classes = useStyles();
   const modulesManager = useModulesManager();
@@ -50,7 +50,10 @@ function BenefitPlanTabPanel({
 
   const tabStyle = (tab) => (isSelected(tab) ? classes.selectedTab : classes.unselectedTab);
 
-  const handleChange = (_, tab) => setActiveTab(tab);
+  const handleChange = (_, tab) => {
+    setActiveTab(tab);
+    onActiveTabChange(tab);
+  };
 
   const payrollCreateRights = modulesManager.getRef(PAYROLL_CREATE_RIGHTS_PUB_REF);
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -65,6 +65,8 @@ export const BENEFICIARY_STATUS = {
   SUSPENDED: 'SUSPENDED',
 };
 
+export const DEFAULT_BENEFICIARY_STATUS = 'POTENTIAL';
+
 export const FIELD_TYPES = {
   INTEGER: 'integer',
   NUMBER: 'number',

--- a/src/pages/BenefitPlanPage.js
+++ b/src/pages/BenefitPlanPage.js
@@ -16,7 +16,11 @@ import _ from 'lodash';
 import { withTheme, withStyles } from '@material-ui/core/styles';
 import DeleteIcon from '@material-ui/icons/Delete';
 import PauseIcon from '@material-ui/icons/Pause';
-import { RIGHT_BENEFICIARY_SEARCH, RIGHT_BENEFIT_PLAN_UPDATE } from '../constants';
+import {
+  BENEFIT_PLAN_BENEFICIARIES_LIST_TAB_VALUE,
+  RIGHT_BENEFICIARY_SEARCH,
+  RIGHT_BENEFIT_PLAN_UPDATE,
+} from '../constants';
 import {
   fetchBenefitPlan, deleteBenefitPlan, closeBenefitPlan, updateBenefitPlan, clearBenefitPlan, createBenefitPlan,
 } from '../actions';
@@ -178,6 +182,8 @@ function BenefitPlanPage({
     );
   };
 
+  const [childActiveTab, setChildActiveTab] = useState(BENEFIT_PLAN_BENEFICIARIES_LIST_TAB_VALUE);
+
   const getBenefitPlanPanels = () => {
     const panels = [];
     if (benefitPlan?.id && benefitPlan?.beneficiaryDataSchema) {
@@ -220,6 +226,8 @@ function BenefitPlanPage({
         save={handleSave}
         HeadPanel={BenefitPlanHeadPanel}
         Panels={getBenefitPlanPanels()}
+        onActiveTabChange={setChildActiveTab}
+        activeTab={childActiveTab}
         rights={rights}
         actions={actions}
         setConfirmedAction={setConfirmedAction}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -124,7 +124,7 @@
   "socialProtection.benefitUploadRecord.sourceName": "Filename",
   "socialProtection.benefitUploadRecord.workflow": "Workflow",
   "socialProtection.benefitUploadRecord.percentageOfInvalidItems": "Percentage of invalid items",
-  "socialProtection.benefitPlan.BenefitPlanEligibilityCriteriaPanel.title": "Default Enrollment Criteria",
+  "socialProtection.benefitPlan.BenefitPlanEligibilityCriteriaPanel.title": "{beneficiaryStatus} Beneficiary Enrollment Criteria",
   "socialProtection.benefitPlan.benefitPlanBeneficiaries.uploadHistoryTable.downloadUploadFile": "Download Upload File",
   "socialProtection.benefitPlan.benefitPlanBeneficiaries.uploadHistoryTable.downloadInvalidItems": "Download Invalid Items",
   "socialProtection.benefitPlan.benefitPlanBeneficiaries.uploadHistoryTable.validationErrors": "Validation Errors",


### PR DESCRIPTION
This change set allows for a plan to have eligibility criteria set for each of its beneficiary status, as a country usecase requires such flexibilty during the enrollment process, for example graduated beneficiay qualifying criteria would be different from that of active beneficiaries.

It requires migrating the `advanced_criteria` on BenefitPlan's json_ext field from [filters] to {status: filters}. Backward compatibility and array to object migration is handled in this PR. 

Manually tested. Workflow gif attached:
![status_linked_eligibility_with_migration](https://github.com/user-attachments/assets/564b8f71-23ed-4e65-9f41-a8850b28fabf)