### PR TITLE
OP-2330: fixed optional field processing in tasks

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -266,13 +266,13 @@ function formatBenefitPlanGQL(benefitPlan) {
     ${benefitPlan?.code ? `code: "${formatGQLString(benefitPlan.code)}"` : ''}
     ${benefitPlan?.maxBeneficiaries ? `maxBeneficiaries: ${benefitPlan.maxBeneficiaries}` : ''}
     ${benefitPlan?.ceilingPerBeneficiary ? `ceilingPerBeneficiary: "${benefitPlan.ceilingPerBeneficiary}"` : ''}
-    ${benefitPlan?.institution ? `institution: "${formatGQLString(benefitPlan.institution)}"` : ''}
+    ${benefitPlan?.institution ? `institution: "${formatGQLString(benefitPlan.institution)}"` : 'institution: ""'}
     ${benefitPlan?.type ? `type: ${benefitPlan.type}` : ''}
     ${benefitPlan?.dateValidFrom ? `dateValidFrom: "${dateTimeToDate(benefitPlan.dateValidFrom)}"` : ''}
     ${benefitPlan?.dateValidTo ? `dateValidTo: "${dateTimeToDate(benefitPlan.dateValidTo)}"` : ''}
-    ${benefitPlan?.description ? `description: "${formatGQLString(benefitPlan.description)}"` : ''}
+    ${benefitPlan?.description ? `description: "${formatGQLString(benefitPlan.description)}"` : 'description: ""'}
     ${benefitPlan?.beneficiaryDataSchema
-    ? `beneficiaryDataSchema: ${JSON.stringify(benefitPlan.beneficiaryDataSchema)}` : ''}
+    ? `beneficiaryDataSchema: ${JSON.stringify(benefitPlan.beneficiaryDataSchema)}` : 'beneficiaryDataSchema: "{}"'}
     ${benefitPlan?.jsonExt ? `jsonExt: ${JSON.stringify(benefitPlan.jsonExt)}` : ''}`;
 }
 

--- a/src/components/BenefitPlanHeadPanel.js
+++ b/src/components/BenefitPlanHeadPanel.js
@@ -136,7 +136,9 @@ class BenefitPlanHeadPanel extends FormPanel {
             displayZero
             module="socialProtection"
             label="benefitPlan.maxBeneficiaries"
-            onChange={(v) => this.updateAttribute('maxBeneficiaries', v)}
+            onChange={(v) => {
+              this.updateAttribute('maxBeneficiaries', v === '' ? null : v);
+            }}
             value={benefitPlan?.maxBeneficiaries ?? ''}
           />
         </Grid>


### PR DESCRIPTION
TICKET: https://openimis.atlassian.net/browse/OP-2330

Now optional fields should be changed when we want to remove them into ‘null'/’empty' values.

Example:

1. Before changing benefit plan entity:
![Screenshot from 2025-02-13 15-53-14](https://github.com/user-attachments/assets/7c0ac990-db73-46d3-906e-014605bd88ba)
    2. Task responsible for updating benefit plan
![Screenshot from 2025-02-13 15-53-40](https://github.com/user-attachments/assets/234051b3-da91-494f-8e59-a6f998efd248)
     3. Applied change - works as expected
![Screenshot from 2025-02-13 15-53-48](https://github.com/user-attachments/assets/d8fe515f-c90d-41a0-bc67-7bb5a858c1c7)
