### PR TITLE
Fix BenefitPlanEligibilityCriteriaPanel display by moving to benefici…

### DIFF
--- a/src/components/BenefitPlanBeneficiariesTabPanel.js
+++ b/src/components/BenefitPlanBeneficiariesTabPanel.js
@@ -18,7 +18,9 @@ import {
   DEDUPLICATION_SELECT_FIELD_DIALOG_CONTRIBUTION_KEY,
   PAYROLL_CREATE_RIGHTS_PUB_REF,
   PAYROLL_PAYROLL_ROUTE,
+  RIGHT_BENEFIT_PLAN_UPDATE,
 } from '../constants';
+import BenefitPlanEligibilityCriteriaPanel from './BenefitPlanEligibilityCriteriaPanel';
 import BenefitPlanBeneficiariesUploadDialog from '../dialogs/BenefitPlanBeneficiariesUploadDialog';
 import BenefitPlanBeneficiariesUploadHistoryDialog from '../dialogs/BenefitPlanBeneficiariesUploadHistoryDialog';
 
@@ -37,7 +39,8 @@ function BenefitPlanBeneficiariesTabLabel({
 }
 
 function BenefitPlanBeneficiariesTabPanel({
-  intl, rights, benefitPlan, setConfirmedAction, value, classes,
+  intl, rights, benefitPlan, setConfirmedAction, value, classes, confirmed,
+  edited, onEditedChanged,
 }) {
   if (value !== BENEFIT_PLAN_BENEFICIARIES_TAB_WRAPPER_VALUE) {
     return null;
@@ -117,6 +120,15 @@ function BenefitPlanBeneficiariesTabPanel({
         </div>
       </Grid>
       <Grid item xs={12}>
+        {rights.includes(RIGHT_BENEFIT_PLAN_UPDATE) && benefitPlan?.id && (
+          <BenefitPlanEligibilityCriteriaPanel
+            confirmed={confirmed}
+            edited={edited}
+            benefitPlan={benefitPlan}
+            onEditedChanged={onEditedChanged}
+            activeTab={activeTab}
+          />
+        )}
         <Contributions
           contributionKey={BENEFIT_PLAN_BENEFICIARY_TABS_PANEL_CONTRIBUTION_KEY}
           rights={rights}

--- a/src/components/BenefitPlanTabPanel.js
+++ b/src/components/BenefitPlanTabPanel.js
@@ -35,7 +35,8 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 function BenefitPlanTabPanel({
-  intl, rights, benefitPlan, setConfirmedAction, onActiveTabChange,
+  intl, rights, benefitPlan, setConfirmedAction, onActiveTabChange, confirmed,
+  edited, onEditedChanged,
 }) {
   const classes = useStyles();
   const [activeTab, setActiveTab] = useState(BENEFIT_PLAN_BENEFICIARIES_TAB_WRAPPER_VALUE);
@@ -70,6 +71,9 @@ function BenefitPlanTabPanel({
         benefitPlan={benefitPlan}
         setConfirmedAction={setConfirmedAction}
         classes={classes}
+        confirmed={confirmed}
+        edited={edited}
+        onEditedChanged={onEditedChanged}
       />
     </Paper>
   );

--- a/src/pages/BenefitPlanPage.js
+++ b/src/pages/BenefitPlanPage.js
@@ -27,7 +27,6 @@ import {
 import BenefitPlanHeadPanel from '../components/BenefitPlanHeadPanel';
 import BenefitPlanTabPanel from '../components/BenefitPlanTabPanel';
 import { ACTION_TYPE } from '../reducer';
-import BenefitPlanEligibilityCriteriaPanel from '../components/BenefitPlanEligibilityCriteriaPanel';
 
 const styles = (theme) => ({
   page: theme.page,
@@ -186,9 +185,6 @@ function BenefitPlanPage({
 
   const getBenefitPlanPanels = () => {
     const panels = [];
-    if (benefitPlan?.id && benefitPlan?.beneficiaryDataSchema) {
-      panels.push(BenefitPlanEligibilityCriteriaPanel);
-    }
     if (rights.includes(RIGHT_BENEFICIARY_SEARCH)) {
       panels.push(BenefitPlanTabPanel);
     }


### PR DESCRIPTION
## Summary
- Fix BenefitPlanEligibilityCriteriaPanel not displaying
- Move eligibility criteria panel from standalone to embedded within beneficiaries tab

## Changes
- **BenefitPlanPage.js**: Remove standalone panel for eligibility criteria
- **BenefitPlanTabPanel.js**: Pass through required props for eligibility panel
- **BenefitPlanBeneficiariesTabPanel.js**: Embed eligibility criteria panel

## Test plan
- [ ] Verify eligibility criteria panel displays within beneficiaries tab when user has update rights
- [ ] Test that eligibility criteria functionality works as expected (add/remove filters)