### PR TITLE
fix: project path upon successful creation

### DIFF
--- a/src/components/BenefitPlanProjectsSearcher.js
+++ b/src/components/BenefitPlanProjectsSearcher.js
@@ -239,7 +239,7 @@ function BenefitPlanProjectsSearcher({
 
   const onAdd = () => {
     history.push({
-      pathname: `${benefitPlanId}/${modulesManager.getRef('socialProtection.route.project')}`,
+      pathname: `${benefitPlanId}/project`,
       state: {
         benefitPlanId,
         benefitPlanName,

--- a/src/pages/ProjectPage.js
+++ b/src/pages/ProjectPage.js
@@ -120,8 +120,7 @@ function ProjectPage({
       setEditedProject(project);
     }
     if (!projectUuid && project?.id) {
-      const projectRouteRef = modulesManager.getRef('socialProtection.route.project');
-      history.replace(`/${projectRouteRef}/${project.id}`);
+      history.replace(`project/${project.id}`);
       setReset(true);
     }
   }, [project]);

--- a/src/pages/ProjectPage.js
+++ b/src/pages/ProjectPage.js
@@ -139,7 +139,9 @@ function ProjectPage({
         ACTION_TYPE.DELETE_PROJECT,
         ACTION_TYPE.UNDO_DELETE_PROJECT,
       ].includes(mutation?.actionType)) {
-        back();
+        history.push(
+          `/${modulesManager.getRef('socialProtection.route.benefitPlan')}/${benefitPlanId}`,
+        );
       }
     }
     if (mutation?.clientMutationId && !projectUuid) {


### PR DESCRIPTION
- Prior to the fix, upon successful project creation it shows a 404 page. This fixes it and shows the created project page instead.
- Additionally, with the previous implementation, if the project page is visited directly with a URL, following the deletion it would redirect home. The PR makes project post deletion/restore always redirect to program instead of depending on history.

@zikani03 I discovered these two redirect bugs while adding UAT test cases. Please include this fix with the upcoming release.