### PR TITLE
added translation for benefitplan keyword to program for input fields i.e. drop downs

### DIFF
--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1,4 +1,5 @@
 {
+  "socialProtection.BenefitPlan": "Program",
   "socialProtection.benefitPlan.delete.confirm.title": "Delete program {code} {name}",
   "socialProtection.benefitPlan.delete.confirm.message": "Are you sure you want to delete the program?",
   "socialProtection.benefitPlan.delete.mutationLabel": "Delete program {id}",


### PR DESCRIPTION
This PR updates the BenefitPlan -> Program in the dropdowns that use this key(socialProtection.BenefitPlan), which was missing from the module. I have added this key in Lokalise as well, so that it is in sync. 