### PR TITLE
Add missing BenefitPlanPicker label

### DIFF
--- a/src/pickers/BenefitPlanPicker.js
+++ b/src/pickers/BenefitPlanPicker.js
@@ -85,7 +85,7 @@ function BenefitPlanPicker(props) {
             /* eslint-disable-next-line react/jsx-props-no-spreading */
             {...inputProps}
             required={required}
-            label={(withLabel && (label || nullLabel)) || formatMessage('BenefitPlan')}
+            label={(withLabel && (label || nullLabel)) || formatMessage('BenefitPlanPicker.label')}
             placeholder={(withPlaceholder && placeholder) || formatMessage('BenefitPlanPicker.placeholder')}
           />
         </Tooltip>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -103,6 +103,7 @@
   "socialProtection.beneficiary.task.individual.id": "Individual",
   "socialProtection.beneficiary.task.benefitPlan.id": "Program",
   "socialProtection.calculation.tasks.title": "Payment Verification Tasks",
+  "socialProtection.BenefitPlanPicker.label": "Program",
   "socialProtection.BenefitPlanPicker.placeholder": "Please select a Program",
   "socialProtection.benefitPlan.suspend.confirm.title": "Suspend program {code} {name}",
   "socialProtection.benefitPlan.suspend.confirm.message": "Are you sure you want to suspend the program?",


### PR DESCRIPTION
The BenefitPlanPicker label translation wasn't resolving. This fixes it and conforms with existing convention.