### PR TITLE
Fixes and Improve Vite Migrations Round 2 review

### DIFF
--- a/src/components/BenefitPlanSearcher.jsx
+++ b/src/components/BenefitPlanSearcher.jsx
@@ -134,8 +134,10 @@ function BenefitPlanSearcher({
           {rights.includes(RIGHT_BENEFIT_PLAN_UPDATE) && (
             <Tooltip title={formatMessage(intl, 'benefitPlan', 'editButtonTooltip')}>
               <IconButton
-                href={benefitPlanUpdatePageUrl(benefitPlan)}
-                onClick={(e) => e.stopPropagation() && onDoubleClick(benefitPlan)}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onDoubleClick(benefitPlan);
+                }}
                 disabled={deletedBenefitPlanUuids.includes(benefitPlan.id)}
               >
                 <EditIcon />

--- a/src/dialogs/BenefitPlanBeneficiariesUploadDialog.jsx
+++ b/src/dialogs/BenefitPlanBeneficiariesUploadDialog.jsx
@@ -152,6 +152,10 @@ function BenefitPlanBeneficiariesUploadDialog({
       });
 
       if (response.ok) {
+        coreAlert(
+          formatMessage(intl, 'socialProtection', 'benefitPlan.benefitPlanBeneficiaries.upload.success.title'),
+          formatMessage(intl, 'socialProtection', 'benefitPlan.benefitPlanBeneficiaries.upload.success.message'),
+        );
         handleClose();
         return;
       }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -63,6 +63,8 @@
   "socialProtection.benefitPlan.benefitPlanBeneficiariesPotential.label": "Potential",
   "socialProtection.benefitPlan.benefitPlanBeneficiaries.upload": "Upload",
   "socialProtection.benefitPlan.benefitPlanBeneficiaries.upload.label": "Upload Beneficiaries",
+  "socialProtection.benefitPlan.benefitPlanBeneficiaries.upload.success.title": "Upload successful",
+  "socialProtection.benefitPlan.benefitPlanBeneficiaries.upload.success.message": "File uploaded successfully and sent to the task group for approval.",
   "socialProtection.mainMenuSocialProtection": "Social Protection",
   "socialProtection.advancedFilters": "Advanced Filters",
   "socialProtection.createButton.tooltip": "Create",


### PR DESCRIPTION
# Description

- Use React `historyPush` for navigation instead of URL reloads for faster page transitions.

# Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires https://github.com/openimis/openimis-fe-social_protection_js/pull/132
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

Upload screenshots/gifs or link to any demo video here.

## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
