### PR TITLE
Fix: format numbers of beneficiaries and working days as int [OP-2988]

### DIFF
--- a/src/components/BenefitPackagePlanPanel.js
+++ b/src/components/BenefitPackagePlanPanel.js
@@ -128,6 +128,7 @@ class BenefitPackagePlanPanel extends FormPanel {
                 <NumberInput
                   min={0}
                   displayZero
+                  numberOfDecimals={0}
                   module="socialProtection"
                   label="benefitPlan.maxBeneficiaries"
                   value={benefitPlan?.maxBeneficiaries ?? ''}

--- a/src/components/BenefitPlanHeadPanel.js
+++ b/src/components/BenefitPlanHeadPanel.js
@@ -132,6 +132,7 @@ class BenefitPlanHeadPanel extends FormPanel {
           <NumberInput
             min={0}
             displayZero
+            numberOfDecimals={0}
             module="socialProtection"
             label="benefitPlan.maxBeneficiaries"
             onChange={(v) => {

--- a/src/components/ProjectHeadPanel.js
+++ b/src/components/ProjectHeadPanel.js
@@ -100,6 +100,7 @@ class ProjectHeadPanel extends FormPanel {
             required
             readOnly={readOnly}
             min={1}
+            numberOfDecimals={0}
             value={project?.targetBeneficiaries}
             onChange={(v) => this.updateAttribute('targetBeneficiaries', v)}
           />
@@ -112,6 +113,7 @@ class ProjectHeadPanel extends FormPanel {
             required
             readOnly={readOnly}
             min={1}
+            numberOfDecimals={0}
             value={project?.workingDays}
             onChange={(v) => this.updateAttribute('workingDays', v)}
           />


### PR DESCRIPTION
# Description

Fix: format numbers of beneficiaries and working days as int instead of decimals

# Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [x] Requires https://github.com/openimis/openimis-fe-core_js/pull/308
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [x] External reference (e.g., Jira): https://openimis.atlassian.net/browse/OP-2988

## Demo

Upload screenshots/gifs or link to any demo video here.

## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
