### PR TITLE
Fix: Cap the max working days

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,4 +54,4 @@ None
 * `state.core.user`, to access user info (rights,...)
 
 ## Configurations Options
-None
+* `maxWorkingDays`: Maximum number of working days allowed for a project. This limits both the input validation on the project form and the number of day columns rendered in the beneficiaries table. Default: `1000`

--- a/README.md
+++ b/README.md
@@ -53,5 +53,5 @@ None
 ## Other Modules Redux State Bindings
 * `state.core.user`, to access user info (rights,...)
 
-## Configurations Options
+## Configuration Options
 * `maxWorkingDays`: Maximum number of working days allowed for a project. This limits both the input validation on the project form and the number of day columns rendered in the beneficiaries table. Default: `1000`

--- a/src/actions.js
+++ b/src/actions.js
@@ -55,8 +55,7 @@ const BENEFICIARY_PROJECTION = (modulesManager) => [
 
 const PROJECT_BENEFICIARY_PROJECTION = (modulesManager) => [
   ...BENEFICIARY_PROJECTION(modulesManager),
-  'project {id}',
-  'projectTimeEntries { id, dayNumber, percentComplete }',
+  'projectEnrollments { id, project {id}, timeEntries { id, dayNumber, percentComplete } }',
 ];
 
 const GROUP_BENEFICIARY_PROJECTION = (modulesManager) => {
@@ -73,8 +72,7 @@ const GROUP_BENEFICIARY_PROJECTION = (modulesManager) => {
 
 const PROJECT_GROUP_BENEFICIARY_PROJECTION = (modulesManager) => [
   ...GROUP_BENEFICIARY_PROJECTION(modulesManager),
-  'project {id}',
-  'projectTimeEntries { id, dayNumber, percentComplete }',
+  'projectEnrollments { id, project {id}, timeEntries { id, dayNumber, percentComplete } }',
 ];
 
 const WORKFLOWS_FULL_PROJECTION = () => [
@@ -793,12 +791,7 @@ function formatTimeEntriesGQL(timeEntries) {
     if (entry.id) {
       fields.push(`id: "${entry.id}"`);
     }
-    if (entry.beneficiaryId) {
-      fields.push(`beneficiaryId: "${entry.beneficiaryId}"`);
-    }
-    if (entry.groupBeneficiaryId) {
-      fields.push(`groupBeneficiaryId: "${entry.groupBeneficiaryId}"`);
-    }
+    fields.push(`enrollmentId: "${entry.enrollmentId}"`);
     fields.push(`dayNumber: ${entry.dayNumber}`);
     fields.push(`percentComplete: ${entry.percentComplete}`);
 
@@ -810,7 +803,7 @@ function formatTimeEntriesGQL(timeEntries) {
 
 export function bulkUpdateBeneficiaryTimeEntries(params, clientMutationLabel) {
   const timeEntriesGQL = formatTimeEntriesGQL(params.timeEntries || []);
-  const gqlParams = `projectId: "${params.projectId}", timeEntries: ${timeEntriesGQL}`;
+  const gqlParams = `timeEntries: ${timeEntriesGQL}`;
 
   const mutation = formatMutation(
     'bulkUpdateBeneficiaryTimeEntries',
@@ -837,7 +830,7 @@ export function bulkUpdateBeneficiaryTimeEntries(params, clientMutationLabel) {
 
 export function bulkUpdateGroupBeneficiaryTimeEntries(params, clientMutationLabel) {
   const timeEntriesGQL = formatTimeEntriesGQL(params.timeEntries || []);
-  const gqlParams = `projectId: "${params.projectId}", timeEntries: ${timeEntriesGQL}`;
+  const gqlParams = `timeEntries: ${timeEntriesGQL}`;
 
   const mutation = formatMutation(
     'bulkUpdateGroupBeneficiaryTimeEntries',

--- a/src/actions.js
+++ b/src/actions.js
@@ -779,3 +779,82 @@ export function enrollGroupProject(params, clientMutationLabel) {
     },
   );
 }
+
+function formatTimeEntriesGQL(timeEntries) {
+  if (!timeEntries || timeEntries.length === 0) {
+    return '[]';
+  }
+
+  const formatted = timeEntries.map((entry) => {
+    const fields = [];
+    if (entry.id) {
+      fields.push(`id: "${entry.id}"`);
+    }
+    if (entry.beneficiaryId) {
+      fields.push(`beneficiaryId: "${entry.beneficiaryId}"`);
+    }
+    if (entry.groupBeneficiaryId) {
+      fields.push(`groupBeneficiaryId: "${entry.groupBeneficiaryId}"`);
+    }
+    fields.push(`dayNumber: ${entry.dayNumber}`);
+    fields.push(`percentComplete: ${entry.percentComplete}`);
+
+    return `{ ${fields.join(', ')} }`;
+  });
+
+  return `[${formatted.join(', ')}]`;
+}
+
+export function bulkUpdateBeneficiaryTimeEntries(params, clientMutationLabel) {
+  const timeEntriesGQL = formatTimeEntriesGQL(params.timeEntries || []);
+  const gqlParams = `projectId: "${params.projectId}", timeEntries: ${timeEntriesGQL}`;
+
+  const mutation = formatMutation(
+    'bulkUpdateBeneficiaryTimeEntries',
+    gqlParams,
+    clientMutationLabel,
+  );
+
+  const requestedDateTime = new Date();
+
+  return graphql(
+    mutation.payload,
+    [
+      REQUEST(ACTION_TYPE.MUTATION),
+      SUCCESS(ACTION_TYPE.BULK_UPDATE_BENEFICIARY_TIME_ENTRIES),
+      ERROR(ACTION_TYPE.MUTATION),
+    ],
+    {
+      clientMutationId: mutation.clientMutationId,
+      clientMutationLabel,
+      requestedDateTime,
+    },
+  );
+}
+
+export function bulkUpdateGroupBeneficiaryTimeEntries(params, clientMutationLabel) {
+  const timeEntriesGQL = formatTimeEntriesGQL(params.timeEntries || []);
+  const gqlParams = `projectId: "${params.projectId}", timeEntries: ${timeEntriesGQL}`;
+
+  const mutation = formatMutation(
+    'bulkUpdateGroupBeneficiaryTimeEntries',
+    gqlParams,
+    clientMutationLabel,
+  );
+
+  const requestedDateTime = new Date();
+
+  return graphql(
+    mutation.payload,
+    [
+      REQUEST(ACTION_TYPE.MUTATION),
+      SUCCESS(ACTION_TYPE.BULK_UPDATE_GROUP_BENEFICIARY_TIME_ENTRIES),
+      ERROR(ACTION_TYPE.MUTATION),
+    ],
+    {
+      clientMutationId: mutation.clientMutationId,
+      clientMutationLabel,
+      requestedDateTime,
+    },
+  );
+}

--- a/src/actions.js
+++ b/src/actions.js
@@ -44,24 +44,34 @@ const UPLOAD_HISTORY_FULL_PROJECTION = () => [
   'dataUpload {uuid, dateCreated, dateUpdated, sourceName, sourceType, status, error, userCreated {username} }',
 ];
 
-const BENEFICIARY_FULL_PROJECTION = (modulesManager) => [
+const BENEFICIARY_PROJECTION = (modulesManager) => [
   'id',
   'benefitPlan {id}',
-  'project {id}',
   'individual {firstName, lastName, dob, location' + modulesManager.getProjection('location.Location.FlatProjection') + '}',
   'status',
   'isEligible',
   'jsonExt',
 ];
 
-const GROUP_BENEFICIARY_FULL_PROJECTION = (modulesManager) => [
+const PROJECT_BENEFICIARY_PROJECTION = (modulesManager) => [
+  ...BENEFICIARY_PROJECTION(modulesManager),
+  'project {id}',
+  'projectTimeEntries { id, dayNumber, percentComplete }',
+];
+
+const GROUP_BENEFICIARY_PROJECTION = (modulesManager) => [
   'id',
   'benefitPlan {id}',
-  'project {id}',
   'group {id, code, head {uuid, firstName, lastName, dob}, location' + modulesManager.getProjection('location.Location.FlatProjection') + '}',
   'status',
   'isEligible',
   'jsonExt',
+];
+
+const PROJECT_GROUP_BENEFICIARY_PROJECTION = (modulesManager) => [
+  ...GROUP_BENEFICIARY_PROJECTION(modulesManager),
+  'project {id}',
+  'projectTimeEntries { id, dayNumber, percentComplete }',
 ];
 
 const WORKFLOWS_FULL_PROJECTION = () => [
@@ -92,12 +102,12 @@ export function fetchBenefitPlans(params) {
 }
 
 export function fetchBeneficiaries(modulesManager, params) {
-  const payload = formatPageQueryWithCount('beneficiary', params, BENEFICIARY_FULL_PROJECTION(modulesManager));
+  const payload = formatPageQueryWithCount('beneficiary', params, BENEFICIARY_PROJECTION(modulesManager));
   return graphql(payload, ACTION_TYPE.SEARCH_BENEFICIARIES);
 }
 
 export function fetchProjectBeneficiaries(modulesManager, params, meta = {}) {
-  const payload = formatPageQueryWithCount('beneficiary', params, BENEFICIARY_FULL_PROJECTION(modulesManager));
+  const payload = formatPageQueryWithCount('beneficiary', params, PROJECT_BENEFICIARY_PROJECTION(modulesManager));
   return graphql(payload, ACTION_TYPE.SEARCH_PROJECT_BENEFICIARIES, meta);
 }
 
@@ -105,7 +115,7 @@ export function fetchGroupBeneficiaries(modulesManager, params) {
   const payload = formatPageQueryWithCount(
     'groupBeneficiary',
     params,
-    GROUP_BENEFICIARY_FULL_PROJECTION(modulesManager),
+    GROUP_BENEFICIARY_PROJECTION(modulesManager),
   );
   return graphql(payload, ACTION_TYPE.SEARCH_GROUP_BENEFICIARIES);
 }
@@ -114,7 +124,7 @@ export function fetchProjectGroupBeneficiaries(modulesManager, params, meta = {}
   const payload = formatPageQueryWithCount(
     'groupBeneficiary',
     params,
-    GROUP_BENEFICIARY_FULL_PROJECTION(modulesManager),
+    PROJECT_GROUP_BENEFICIARY_PROJECTION(modulesManager),
   );
   return graphql(payload, ACTION_TYPE.SEARCH_PROJECT_GROUP_BENEFICIARIES, meta);
 }

--- a/src/actions.js
+++ b/src/actions.js
@@ -47,7 +47,7 @@ const UPLOAD_HISTORY_FULL_PROJECTION = () => [
 const BENEFICIARY_PROJECTION = (modulesManager) => [
   'id',
   'benefitPlan {id}',
-  'individual {firstName, lastName, dob, location' + modulesManager.getProjection('location.Location.FlatProjection') + '}',
+  `individual {firstName, lastName, dob, location${modulesManager.getProjection('location.Location.FlatProjection')}}`,
   'status',
   'isEligible',
   'jsonExt',
@@ -59,14 +59,17 @@ const PROJECT_BENEFICIARY_PROJECTION = (modulesManager) => [
   'projectTimeEntries { id, dayNumber, percentComplete }',
 ];
 
-const GROUP_BENEFICIARY_PROJECTION = (modulesManager) => [
-  'id',
-  'benefitPlan {id}',
-  'group {id, code, head {uuid, firstName, lastName, dob}, location' + modulesManager.getProjection('location.Location.FlatProjection') + '}',
-  'status',
-  'isEligible',
-  'jsonExt',
-];
+const GROUP_BENEFICIARY_PROJECTION = (modulesManager) => {
+  const locationProjection = modulesManager.getProjection('location.Location.FlatProjection');
+  return [
+    'id',
+    'benefitPlan {id}',
+    `group {id, code, head {uuid, firstName, lastName, dob}, location${locationProjection}}`,
+    'status',
+    'isEligible',
+    'jsonExt',
+  ];
+};
 
 const PROJECT_GROUP_BENEFICIARY_PROJECTION = (modulesManager) => [
   ...GROUP_BENEFICIARY_PROJECTION(modulesManager),
@@ -87,7 +90,7 @@ const PROJECT_FULL_PROJECTION = (modulesManager) => [
   'targetBeneficiaries',
   'workingDays',
   'activity {id, name}',
-  'location' + modulesManager.getProjection('location.Location.FlatProjection'),
+  `location${modulesManager.getProjection('location.Location.FlatProjection')}`,
   'allowsMultipleEnrollments',
   'isDeleted',
   'userUpdated {username}',

--- a/src/components/BeneficiaryTable.js
+++ b/src/components/BeneficiaryTable.js
@@ -410,7 +410,10 @@ function BeneficiaryTable({
       width: typeof c.field === 'string' && c.field.includes('email') ? '200px' : '140px',
       tableData: { filterValue: initialFiltersRef.current[c.title] || '' },
     }));
-  }, [isGroup, nameDoBFieldPrefix, locationFieldPrefix, translate, dynamicColumns, workingDays, onTimeEntryChange, maxWorkingDays]);
+  }, [
+    isGroup, nameDoBFieldPrefix, locationFieldPrefix, translate,
+    dynamicColumns, workingDays, onTimeEntryChange, maxWorkingDays,
+  ]);
 
   const isSelectable = !!onSelectionChange;
 

--- a/src/components/BeneficiaryTable.js
+++ b/src/components/BeneficiaryTable.js
@@ -203,6 +203,11 @@ const getWorkDayColumns = (translateFn, workingDays = 0) => {
       customFilterAndSearch: createNumericFilterFn(
         (rowData) => rowData.projectTimeEntriesDict?.[`day${dayNumber}`]?.percentComplete,
       ),
+      customSort: (a, b) => {
+        const aVal = a.projectTimeEntriesDict?.[`day${dayNumber}`]?.percentComplete ?? 0;
+        const bVal = b.projectTimeEntriesDict?.[`day${dayNumber}`]?.percentComplete ?? 0;
+        return aVal - bVal;
+      },
       align: 'center',
       width: '100px',
     };

--- a/src/components/BeneficiaryTable.js
+++ b/src/components/BeneficiaryTable.js
@@ -92,8 +92,7 @@ const getDynamicColumns = (translateFn, customFilters = []) => {
 
           filterFn = (filter, rowData) => {
             const value = rowData.jsonExt?.[field];
-            if (value === null || value === undefined) return false;
-            const numValue = Number(value);
+            const numValue = (value === null || value === undefined) ? 0 : Number(value);
 
             // Handle case when filter is a string (global search)
             if (typeof filter === 'string') {
@@ -162,8 +161,7 @@ const getWorkDayColumns = (translateFn, workingDays = 0) => {
       filterComponent: NumberFilter,
       customFilterAndSearch: (filter, rowData) => {
         const value = rowData.projectTimeEntriesDict?.[`day${dayNumber}`]?.percentComplete;
-        if (value === null || value === undefined) return false;
-        const numValue = Number(value);
+        const numValue = (value === null || value === undefined) ? 0 : Number(value);
 
         // Same logic as other numeric filters
         if (typeof filter === 'string') {

--- a/src/components/BeneficiaryTable.js
+++ b/src/components/BeneficiaryTable.js
@@ -353,16 +353,30 @@ function BeneficiaryTable({
         editable: 'never',
         ...(isGroup && { orderField: 'head_dob' }),
       },
-      ...Array.from({ length: LOC_LEVELS }, (_, i) => ({
-        title: translate(`location.locationType.${i}`),
-        type: 'location',
-        level: i,
-        render: (rowData) => locationFormatter(rowData?.[locationFieldPrefix]?.location)[i] || '',
-        customFilterAndSearch: (term, rowData) => {
-          const locName = locationFormatter(rowData?.[locationFieldPrefix]?.location)[i].toLowerCase() || '';
-          return locName.includes(term.toLowerCase());
-        },
-      })),
+      ...Array.from({ length: LOC_LEVELS }, (_, i) => {
+        // Build the orderField path for remote sorting: level 3 (village) = location__name,
+        // level 2 (ward) = location__parent__name, etc.
+        const parentChain = Array(LOC_LEVELS - 1 - i).fill('parent').join('__');
+        const locationPath = parentChain ? `location__${parentChain}__name` : 'location__name';
+        const orderField = `${locationFieldPrefix}__${locationPath}`;
+
+        return {
+          title: translate(`location.locationType.${i}`),
+          type: 'location',
+          level: i,
+          orderField,
+          render: (rowData) => locationFormatter(rowData?.[locationFieldPrefix]?.location)[i] || '',
+          customSort: (a, b) => {
+            const aLoc = locationFormatter(a?.[locationFieldPrefix]?.location)[i] || '';
+            const bLoc = locationFormatter(b?.[locationFieldPrefix]?.location)[i] || '';
+            return aLoc.localeCompare(bLoc);
+          },
+          customFilterAndSearch: (term, rowData) => {
+            const locName = locationFormatter(rowData?.[locationFieldPrefix]?.location)[i].toLowerCase() || '';
+            return locName.includes(term.toLowerCase());
+          },
+        };
+      }),
       ...dynamicColumns,
       ...workDayColumns,
     ];

--- a/src/components/BeneficiaryTable.js
+++ b/src/components/BeneficiaryTable.js
@@ -157,21 +157,15 @@ const getWorkDayColumns = (translateFn, workingDays = 0) => {
     const dayNumber = i + 1;
     return {
       title: `${translateFn('project.day')} ${dayNumber}`,
-      field: `projectTimeEntries.${dayNumber}`,
+      field: `projectTimeEntriesDict.day${dayNumber}.percentComplete`,
       type: 'numeric',
-      render: (rowData) => {
-        const entry = rowData.projectTimeEntries?.find((e) => e.dayNumber === dayNumber);
-        return entry ? entry.percentComplete : '';
-      },
       filterComponent: NumberFilter,
       customFilterAndSearch: (filter, rowData) => {
-        const entry = rowData.projectTimeEntries?.find((e) => e.dayNumber === dayNumber);
-        if (!entry) return false;
-        const value = entry.percentComplete;
+        const value = rowData.projectTimeEntriesDict?.[`day${dayNumber}`]?.percentComplete;
         if (value === null || value === undefined) return false;
         const numValue = Number(value);
 
-        // Apply the same logic as your other numeric filters
+        // Same logic as other numeric filters
         if (typeof filter === 'string') {
           if (filter === '') return true;
           const searchNum = Number(filter);
@@ -350,7 +344,7 @@ function BeneficiaryTable({
 
     return allColumns.map((c) => ({
       ...c,
-      width: c.field && c.field.includes('email') ? '200px' : '140px',
+      width: typeof c.field === 'string' && c.field.includes('email') ? '200px' : '140px',
       tableData: { filterValue: filters[c.title] || '' },
     }));
   }, [additionalColumns, filters, nameDoBFieldPrefix, translate, dynamicColumns]);

--- a/src/components/BeneficiaryTable.js
+++ b/src/components/BeneficiaryTable.js
@@ -156,7 +156,7 @@ const getDynamicColumns = (translateFn, customFilters = []) => {
     });
 };
 
-function PercentageEditField({ value, onChange }) {
+function PercentageEditField({ value, onChange, columnDef }) {
   const numValue = value === undefined || value === null || value === '' ? '' : Number(value);
   const isInvalid = numValue !== '' && (numValue < 0 || numValue > 100);
 
@@ -167,12 +167,12 @@ function PercentageEditField({ value, onChange }) {
       onChange={(e) => onChange(e.target.value)}
       error={isInvalid}
       helperText={isInvalid ? '0-100' : ''}
+      placeholder={columnDef?.title}
       InputProps={{
         min: 0,
         max: 100,
         endAdornment: <InputAdornment position="end">%</InputAdornment>,
       }}
-      style={{ width: '80px' }}
       size="small"
     />
   );

--- a/src/components/BeneficiaryTable.js
+++ b/src/components/BeneficiaryTable.js
@@ -6,6 +6,8 @@ import {
   Select,
   MenuItem,
   Paper,
+  TextField,
+  InputAdornment,
 } from '@material-ui/core';
 import {
   withTheme,
@@ -150,6 +152,27 @@ const getDynamicColumns = (translateFn, customFilters = []) => {
     });
 };
 
+function PercentageEditField({ value, onChange }) {
+  const numValue = value === undefined || value === null || value === '' ? '' : Number(value);
+  const isInvalid = numValue !== '' && (numValue < 0 || numValue > 100);
+
+  return (
+    <TextField
+      type="number"
+      value={numValue}
+      onChange={(e) => onChange(e.target.value)}
+      inputProps={{ min: 0, max: 100 }}
+      error={isInvalid}
+      helperText={isInvalid ? '0-100' : ''}
+      InputProps={{
+        endAdornment: <InputAdornment position="end">%</InputAdornment>,
+      }}
+      style={{ width: '80px' }}
+      size="small"
+    />
+  );
+}
+
 const getWorkDayColumns = (translateFn, workingDays = 0) => {
   if (!workingDays) return [];
   return Array.from({ length: workingDays }, (_, i) => {
@@ -158,7 +181,14 @@ const getWorkDayColumns = (translateFn, workingDays = 0) => {
       title: `${translateFn('project.day')} ${dayNumber}`,
       field: `projectTimeEntriesDict.day${dayNumber}.percentComplete`,
       type: 'numeric',
+      render: (rowData) => {
+        const value = rowData.projectTimeEntriesDict?.[`day${dayNumber}`]?.percentComplete;
+        return value !== undefined && value !== null ? `${value}%` : '';
+      },
       filterComponent: NumberFilter,
+      editComponent: (props) => (
+        <PercentageEditField value={props.value} onChange={props.onChange} />
+      ),
       customFilterAndSearch: (filter, rowData) => {
         const value = rowData.projectTimeEntriesDict?.[`day${dayNumber}`]?.percentComplete;
         const numValue = (value === null || value === undefined) ? 0 : Number(value);

--- a/src/components/BeneficiaryTable.js
+++ b/src/components/BeneficiaryTable.js
@@ -33,6 +33,35 @@ import {
 import NumberFilter from './MaterialTableNumberFilter';
 
 const DEFAULT_CELL_PADDING = '0 0 0 10px';
+
+const createNumericFilterFn = (getValue) => (filter, rowData) => {
+  const value = getValue(rowData);
+  const numValue = (value === null || value === undefined) ? 0 : Number(value);
+
+  // Handle case when filter is a string (global search)
+  if (typeof filter === 'string') {
+    if (filter === '') return true;
+    const searchNum = Number(filter);
+    if (Number.isNaN(searchNum)) return false;
+    return numValue === searchNum;
+  }
+
+  // Handle case when filter is an object (column filter)
+  const filterValue = Number(filter?.value);
+  if (Number.isNaN(numValue)) return false;
+  if (filter?.value === undefined || filter?.value === '') return true;
+  if (Number.isNaN(filterValue)) return false;
+
+  switch (filter?.operator) {
+    case 'exact': return numValue === filterValue;
+    case 'lt': return numValue < filterValue;
+    case 'lte': return numValue <= filterValue;
+    case 'gt': return numValue > filterValue;
+    case 'gte': return numValue >= filterValue;
+    default: return numValue === filterValue;
+  }
+};
+
 const styles = (theme) => ({
   page: theme.page,
   paper: theme.paper.classes,
@@ -93,34 +122,7 @@ const getDynamicColumns = (translateFn, customFilters = []) => {
         case 'integer':
         case 'numeric':
           filterComponent = NumberFilter;
-
-          filterFn = (filter, rowData) => {
-            const value = rowData.jsonExt?.[field];
-            const numValue = (value === null || value === undefined) ? 0 : Number(value);
-
-            // Handle case when filter is a string (global search)
-            if (typeof filter === 'string') {
-              if (filter === '') return true; // Empty search matches all
-              const searchNum = Number(filter);
-              if (Number.isNaN(searchNum)) return false;
-              return numValue === searchNum; // Exact match for global search
-            }
-
-            // Handle case when filter is an object (column filter)
-            const filterValue = Number(filter?.value);
-            if (Number.isNaN(numValue)) return false;
-            if (filter?.value === undefined || filter?.value === '') return true;
-            if (Number.isNaN(filterValue)) return false;
-
-            switch (filter?.operator) {
-              case 'exact': return numValue === filterValue;
-              case 'lt': return numValue < filterValue;
-              case 'lte': return numValue <= filterValue;
-              case 'gt': return numValue > filterValue;
-              case 'gte': return numValue >= filterValue;
-              default: return numValue === filterValue;
-            }
-          };
+          filterFn = createNumericFilterFn((rowData) => rowData.jsonExt?.[field]);
           break;
 
         case 'date':
@@ -198,32 +200,9 @@ const getWorkDayColumns = (translateFn, workingDays = 0) => {
       },
       filterComponent: NumberFilter,
       editComponent: PercentageEditField,
-      customFilterAndSearch: (filter, rowData) => {
-        const value = rowData.projectTimeEntriesDict?.[`day${dayNumber}`]?.percentComplete;
-        const numValue = (value === null || value === undefined) ? 0 : Number(value);
-
-        // Same logic as other numeric filters
-        if (typeof filter === 'string') {
-          if (filter === '') return true;
-          const searchNum = Number(filter);
-          if (Number.isNaN(searchNum)) return false;
-          return numValue === searchNum;
-        }
-
-        const filterValue = Number(filter?.value);
-        if (Number.isNaN(numValue)) return false;
-        if (filter?.value === undefined || filter?.value === '') return true;
-        if (Number.isNaN(filterValue)) return false;
-
-        switch (filter?.operator) {
-          case 'exact': return numValue === filterValue;
-          case 'lt': return numValue < filterValue;
-          case 'lte': return numValue <= filterValue;
-          case 'gt': return numValue > filterValue;
-          case 'gte': return numValue >= filterValue;
-          default: return numValue === filterValue;
-        }
-      },
+      customFilterAndSearch: createNumericFilterFn(
+        (rowData) => rowData.projectTimeEntriesDict?.[`day${dayNumber}`]?.percentComplete,
+      ),
       align: 'center',
       width: '100px',
     };

--- a/src/components/BeneficiaryTable.js
+++ b/src/components/BeneficiaryTable.js
@@ -338,17 +338,20 @@ function BeneficiaryTable({
         title: translate('socialProtection.beneficiary.firstName'),
         field: `${nameDoBFieldPrefix}.firstName`,
         editable: 'never',
+        ...(isGroup && { orderField: 'head_first_name' }),
       },
       {
         title: translate('socialProtection.beneficiary.lastName'),
         field: `${nameDoBFieldPrefix}.lastName`,
         editable: 'never',
         ...(!isGroup && { defaultSort: 'asc' }),
+        ...(isGroup && { orderField: 'head_last_name' }),
       },
       {
         title: translate('socialProtection.beneficiary.dob'),
         field: `${nameDoBFieldPrefix}.dob`,
         editable: 'never',
+        ...(isGroup && { orderField: 'head_dob' }),
       },
       ...Array.from({ length: LOC_LEVELS }, (_, i) => ({
         title: translate(`location.locationType.${i}`),

--- a/src/components/BeneficiaryTable.js
+++ b/src/components/BeneficiaryTable.js
@@ -21,6 +21,7 @@ import { useDispatch } from 'react-redux';
 import {
   formatMessage,
   fetchCustomFilter,
+  useModulesManager,
 } from '@openimis/fe-core';
 import {
   LOC_LEVELS,
@@ -29,6 +30,7 @@ import {
 import {
   MODULE_NAME,
   DEFAULT_PAGE_SIZE,
+  DEFAULT_MAX_WORKING_DAYS,
 } from '../constants';
 import NumberFilter from './MaterialTableNumberFilter';
 
@@ -199,9 +201,10 @@ function TableContainer({ children, className }) {
   );
 }
 
-const getWorkDayColumns = (translateFn, onTimeEntryChange, workingDays = 0) => {
+const getWorkDayColumns = (translateFn, onTimeEntryChange, workingDays = 0, maxColumns = DEFAULT_MAX_WORKING_DAYS) => {
   if (!workingDays) return [];
-  return Array.from({ length: workingDays }, (_, i) => {
+  const cappedDays = Math.min(workingDays, maxColumns);
+  return Array.from({ length: cappedDays }, (_, i) => {
     const dayNumber = i + 1;
     const dayKey = `day${dayNumber}`;
     return {
@@ -258,6 +261,8 @@ function BeneficiaryTable({
   const [jsonExtFilters, setJsonExtFilters] = React.useState({});
 
   const dispatch = useDispatch();
+  const modulesManager = useModulesManager();
+  const maxWorkingDays = modulesManager.getConf('fe-social_protection', 'maxWorkingDays', DEFAULT_MAX_WORKING_DAYS);
 
   const dynamicColumns = React.useMemo(() => (
     getDynamicColumns(translate, jsonExtFilters)
@@ -350,7 +355,7 @@ function BeneficiaryTable({
         defaultSort: 'asc',
       },
     ] : [];
-    const workDayColumns = getWorkDayColumns(translate, onTimeEntryChange, workingDays);
+    const workDayColumns = getWorkDayColumns(translate, onTimeEntryChange, workingDays, maxWorkingDays);
     const allColumns = [
       ...additionalColumns,
       {
@@ -405,7 +410,7 @@ function BeneficiaryTable({
       width: typeof c.field === 'string' && c.field.includes('email') ? '200px' : '140px',
       tableData: { filterValue: initialFiltersRef.current[c.title] || '' },
     }));
-  }, [isGroup, nameDoBFieldPrefix, locationFieldPrefix, translate, dynamicColumns, workingDays, onTimeEntryChange]);
+  }, [isGroup, nameDoBFieldPrefix, locationFieldPrefix, translate, dynamicColumns, workingDays, onTimeEntryChange, maxWorkingDays]);
 
   const isSelectable = !!onSelectionChange;
 

--- a/src/components/BeneficiaryTable.js
+++ b/src/components/BeneficiaryTable.js
@@ -156,15 +156,28 @@ const getDynamicColumns = (translateFn, customFilters = []) => {
     });
 };
 
-function PercentageEditField({ value, onChange, columnDef }) {
+function PercentageEditField({
+  value, onChange, columnDef, rowData, onTimeEntryChange, dayKey,
+}) {
   const numValue = value === undefined || value === null || value === '' ? '' : Number(value);
   const isInvalid = numValue !== '' && (numValue < 0 || numValue > 100);
+
+  const handleChange = (e) => {
+    const newValue = e.target.value;
+    onChange(newValue);
+
+    const effectiveDayKey = dayKey || columnDef?.dayKey;
+    if (onTimeEntryChange && rowData?.enrollmentId && effectiveDayKey) {
+      const originalEntry = rowData.projectTimeEntriesDict?.[effectiveDayKey];
+      onTimeEntryChange(rowData.enrollmentId, effectiveDayKey, newValue, originalEntry, rowData);
+    }
+  };
 
   return (
     <TextField
       type="number"
       value={numValue}
-      onChange={(e) => onChange(e.target.value)}
+      onChange={handleChange}
       error={isInvalid}
       helperText={isInvalid ? '0-100' : ''}
       placeholder={columnDef?.title}
@@ -186,26 +199,30 @@ function TableContainer({ children, className }) {
   );
 }
 
-const getWorkDayColumns = (translateFn, workingDays = 0) => {
+const getWorkDayColumns = (translateFn, workingDays = 0, onTimeEntryChange) => {
   if (!workingDays) return [];
   return Array.from({ length: workingDays }, (_, i) => {
     const dayNumber = i + 1;
+    const dayKey = `day${dayNumber}`;
     return {
       title: `${translateFn('project.day')} ${dayNumber}`,
-      field: `projectTimeEntriesDict.day${dayNumber}.percentComplete`,
+      field: `projectTimeEntriesDict.${dayKey}.percentComplete`,
+      dayKey,
       type: 'numeric',
       render: (rowData) => {
-        const value = rowData.projectTimeEntriesDict?.[`day${dayNumber}`]?.percentComplete;
+        const value = rowData.projectTimeEntriesDict?.[dayKey]?.percentComplete;
         return value !== undefined && value !== null ? `${value}%` : '';
       },
       filterComponent: NumberFilter,
-      editComponent: PercentageEditField,
+      editComponent: (props) => (
+        <PercentageEditField {...props} onTimeEntryChange={onTimeEntryChange} dayKey={dayKey} />
+      ),
       customFilterAndSearch: createNumericFilterFn(
-        (rowData) => rowData.projectTimeEntriesDict?.[`day${dayNumber}`]?.percentComplete,
+        (rowData) => rowData.projectTimeEntriesDict?.[dayKey]?.percentComplete,
       ),
       customSort: (a, b) => {
-        const aVal = a.projectTimeEntriesDict?.[`day${dayNumber}`]?.percentComplete ?? 0;
-        const bVal = b.projectTimeEntriesDict?.[`day${dayNumber}`]?.percentComplete ?? 0;
+        const aVal = a.projectTimeEntriesDict?.[dayKey]?.percentComplete ?? 0;
+        const bVal = b.projectTimeEntriesDict?.[dayKey]?.percentComplete ?? 0;
         return aVal - bVal;
       },
       align: 'center',
@@ -229,6 +246,7 @@ function BeneficiaryTable({
   workingDays,
   tableRef,
   classes,
+  onTimeEntryChange,
 }) {
   const nameDoBFieldPrefix = isGroup ? 'group.head' : 'individual';
   const locationFieldPrefix = isGroup ? 'group' : 'individual';
@@ -331,7 +349,7 @@ function BeneficiaryTable({
         defaultSort: 'asc',
       },
     ] : [];
-    const workDayColumns = getWorkDayColumns(translate, workingDays);
+    const workDayColumns = getWorkDayColumns(translate, workingDays, onTimeEntryChange);
     const allColumns = [
       ...additionalColumns,
       {
@@ -386,7 +404,7 @@ function BeneficiaryTable({
       width: typeof c.field === 'string' && c.field.includes('email') ? '200px' : '140px',
       tableData: { filterValue: initialFiltersRef.current[c.title] || '' },
     }));
-  }, [isGroup, nameDoBFieldPrefix, locationFieldPrefix, translate, dynamicColumns, workingDays]);
+  }, [isGroup, nameDoBFieldPrefix, locationFieldPrefix, translate, dynamicColumns, workingDays, onTimeEntryChange]);
 
   const isSelectable = !!onSelectionChange;
 

--- a/src/components/BeneficiaryTable.js
+++ b/src/components/BeneficiaryTable.js
@@ -5,6 +5,7 @@ import _ from 'lodash';
 import {
   Select,
   MenuItem,
+  Paper,
 } from '@material-ui/core';
 import {
   withTheme,
@@ -27,9 +28,22 @@ import {
 } from '../constants';
 import NumberFilter from './MaterialTableNumberFilter';
 
+const DEFAULT_CELL_PADDING = '0 0 0 10px';
 const styles = (theme) => ({
   page: theme.page,
   paper: theme.paper.classes,
+  containerWrapper: {
+    padding: '0 20px',
+    // Patch style of a nested matertial-table element
+    // so frozen columns work correctly
+    '& > div:nth-child(2) > div:nth-child(2)': {
+      position: 'relative',
+    },
+
+    '& td': {
+      padding: DEFAULT_CELL_PADDING,
+    },
+  },
 });
 
 const getDynamicColumns = (translateFn, customFilters = []) => {
@@ -132,6 +146,7 @@ const getDynamicColumns = (translateFn, customFilters = []) => {
         filterComponent,
         customFilterAndSearch: filterFn,
         align: 'left',
+        editable: 'never',
       };
     });
 };
@@ -197,6 +212,8 @@ function BeneficiaryTable({
   appliedFilters,
   appliedPageSize,
   workingDays,
+  tableRef,
+  classes,
 }) {
   const nameDoBFieldPrefix = isGroup ? 'group.head' : 'individual';
   const locationFieldPrefix = isGroup ? 'group' : 'individual';
@@ -294,6 +311,7 @@ function BeneficiaryTable({
     {
       title: translate('socialProtection.groupBeneficiary.code'),
       field: 'group.code',
+      editable: 'never',
     },
   ] : [];
 
@@ -304,14 +322,17 @@ function BeneficiaryTable({
       {
         title: translate('socialProtection.beneficiary.firstName'),
         field: `${nameDoBFieldPrefix}.firstName`,
+        editable: 'never',
       },
       {
         title: translate('socialProtection.beneficiary.lastName'),
         field: `${nameDoBFieldPrefix}.lastName`,
+        editable: 'never',
       },
       {
         title: translate('socialProtection.beneficiary.dob'),
         field: `${nameDoBFieldPrefix}.dob`,
+        editable: 'never',
       },
       ...Array.from({ length: LOC_LEVELS }, (_, i) => ({
         title: translate(`location.locationType.${i}`),
@@ -336,11 +357,18 @@ function BeneficiaryTable({
 
   const isSelectable = !!onSelectionChange;
 
-  const cellPadding = isSelectable ? '0' : '0 0 0 10px';
+  const cellPadding = isSelectable ? '0' : DEFAULT_CELL_PADDING;
 
   return (
     <ThemeProvider theme={tableTheme}>
       <MaterialTable
+        components={{
+          Container: (props) => (
+            <Paper elevation={2} className={classes.containerWrapper}>
+              {props.children}
+            </Paper>
+          ),
+        }}
         title={tableTitle}
         columns={columns}
         data={onQueryChange || allRows}
@@ -376,6 +404,10 @@ function BeneficiaryTable({
           doubleHorizontalScroll: true,
           tableLayout: 'fixed',
           emptyRowsWhenPaging: false,
+          ...(tableRef.current?.dataManager?.bulkEditOpen
+            ? { fixedColumns: { left: isGroup ? 3 : 2, right: 0 } }
+            : { fixedColumns: {} }),
+          actionsColumnIndex: -1,
         }}
         localization={{
           toolbar: {
@@ -400,7 +432,7 @@ function BeneficiaryTable({
         }}
         onSelectionChange={(rows) => (isSelectable && onSelectionChange(rows))}
         actions={actions}
-        style={{ padding: '0 20px' }}
+        tableRef={tableRef}
       />
     </ThemeProvider>
   );

--- a/src/components/BeneficiaryTable.js
+++ b/src/components/BeneficiaryTable.js
@@ -328,6 +328,7 @@ function BeneficiaryTable({
         title: translate('socialProtection.groupBeneficiary.code'),
         field: 'group.code',
         editable: 'never',
+        defaultSort: 'asc',
       },
     ] : [];
     const workDayColumns = getWorkDayColumns(translate, workingDays);
@@ -342,6 +343,7 @@ function BeneficiaryTable({
         title: translate('socialProtection.beneficiary.lastName'),
         field: `${nameDoBFieldPrefix}.lastName`,
         editable: 'never',
+        ...(!isGroup && { defaultSort: 'asc' }),
       },
       {
         title: translate('socialProtection.beneficiary.dob'),

--- a/src/components/BeneficiaryTable.js
+++ b/src/components/BeneficiaryTable.js
@@ -398,7 +398,7 @@ function BeneficiaryTable({
           doubleHorizontalScroll: true,
           tableLayout: 'fixed',
           emptyRowsWhenPaging: false,
-          ...(tableRef.current?.dataManager?.bulkEditOpen
+          ...(tableRef?.current?.dataManager?.bulkEditOpen
             ? { fixedColumns: { left: isGroup ? 3 : 2, right: 0 } }
             : { fixedColumns: {} }),
           actionsColumnIndex: -1,

--- a/src/components/BeneficiaryTable.js
+++ b/src/components/BeneficiaryTable.js
@@ -1,4 +1,4 @@
-import React, { useMemo, useEffect } from 'react';
+import React, { useMemo, useEffect, useRef, useCallback } from 'react';
 import { injectIntl } from 'react-intl';
 import MaterialTable from 'material-table';
 import _ from 'lodash';
@@ -212,9 +212,9 @@ function BeneficiaryTable({
   const nameDoBFieldPrefix = isGroup ? 'group.head' : 'individual';
   const locationFieldPrefix = isGroup ? 'group' : 'individual';
 
-  const translate = (key) => formatMessage(intl, MODULE_NAME, key);
+  const translate = useCallback((key) => formatMessage(intl, MODULE_NAME, key), [intl]);
 
-  const [filters, setFilters] = React.useState({});
+  const initialFiltersRef = useRef(appliedFilters || {});
   const [jsonExtFilters, setJsonExtFilters] = React.useState({});
 
   const dispatch = useDispatch();
@@ -225,7 +225,7 @@ function BeneficiaryTable({
 
   useEffect(() => {
     if (appliedFilters) {
-      setFilters(appliedFilters);
+      initialFiltersRef.current = appliedFilters;
     }
   }, [appliedFilters]);
 
@@ -301,18 +301,17 @@ function BeneficiaryTable({
     },
   });
 
-  const additionalColumns = isGroup ? [
-    {
-      title: translate('socialProtection.groupBeneficiary.code'),
-      field: 'group.code',
-      editable: 'never',
-    },
-  ] : [];
-
   const columns = useMemo(() => {
+    const additionalColumns = isGroup ? [
+      {
+        title: translate('socialProtection.groupBeneficiary.code'),
+        field: 'group.code',
+        editable: 'never',
+      },
+    ] : [];
     const workDayColumns = getWorkDayColumns(translate, workingDays);
     const allColumns = [
-      ...additionalColumns || [],
+      ...additionalColumns,
       {
         title: translate('socialProtection.beneficiary.firstName'),
         field: `${nameDoBFieldPrefix}.firstName`,
@@ -345,9 +344,9 @@ function BeneficiaryTable({
     return allColumns.map((c) => ({
       ...c,
       width: typeof c.field === 'string' && c.field.includes('email') ? '200px' : '140px',
-      tableData: { filterValue: filters[c.title] || '' },
+      tableData: { filterValue: initialFiltersRef.current[c.title] || '' },
     }));
-  }, [additionalColumns, filters, nameDoBFieldPrefix, translate, dynamicColumns]);
+  }, [isGroup, nameDoBFieldPrefix, locationFieldPrefix, translate, dynamicColumns, workingDays]);
 
   const isSelectable = !!onSelectionChange;
 
@@ -412,17 +411,6 @@ function BeneficiaryTable({
               filterPlaceHolder: translate('projectBeneficiaries.filterPlaceholder'),
             },
           },
-        }}
-        onFilterChange={(appliedFilters) => {
-          // This is only triggered for local data
-          const updatedFilters = {};
-          appliedFilters.forEach((filter) => {
-            if (filter?.value !== undefined) {
-              // keyed by column title because not all columns have field
-              updatedFilters[filter.column.title] = filter.value;
-            }
-          });
-          setFilters(updatedFilters);
         }}
         onSelectionChange={(rows) => (isSelectable && onSelectionChange(rows))}
         actions={actions}

--- a/src/components/BeneficiaryTable.js
+++ b/src/components/BeneficiaryTable.js
@@ -136,6 +136,54 @@ const getDynamicColumns = (translateFn, customFilters = []) => {
     });
 };
 
+const getWorkDayColumns = (translateFn, workingDays = 0) => {
+  if (!workingDays) return [];
+  return Array.from({ length: workingDays }, (_, i) => {
+    const dayNumber = i + 1;
+    return {
+      title: `${translateFn('project.day')} ${dayNumber}`,
+      field: `projectTimeEntries.${dayNumber}`,
+      type: 'numeric',
+      render: (rowData) => {
+        const entry = rowData.projectTimeEntries?.find((e) => e.dayNumber === dayNumber);
+        return entry ? entry.percentComplete : '';
+      },
+      filterComponent: NumberFilter,
+      customFilterAndSearch: (filter, rowData) => {
+        const entry = rowData.projectTimeEntries?.find((e) => e.dayNumber === dayNumber);
+        if (!entry) return false;
+        const value = entry.percentComplete;
+        if (value === null || value === undefined) return false;
+        const numValue = Number(value);
+
+        // Apply the same logic as your other numeric filters
+        if (typeof filter === 'string') {
+          if (filter === '') return true;
+          const searchNum = Number(filter);
+          if (Number.isNaN(searchNum)) return false;
+          return numValue === searchNum;
+        }
+
+        const filterValue = Number(filter?.value);
+        if (Number.isNaN(numValue)) return false;
+        if (filter?.value === undefined || filter?.value === '') return true;
+        if (Number.isNaN(filterValue)) return false;
+
+        switch (filter?.operator) {
+          case 'exact': return numValue === filterValue;
+          case 'lt': return numValue < filterValue;
+          case 'lte': return numValue <= filterValue;
+          case 'gt': return numValue > filterValue;
+          case 'gte': return numValue >= filterValue;
+          default: return numValue === filterValue;
+        }
+      },
+      align: 'center',
+      width: '100px',
+    };
+  });
+};
+
 function BeneficiaryTable({
   intl,
   theme,
@@ -148,6 +196,7 @@ function BeneficiaryTable({
   isGroup,
   appliedFilters,
   appliedPageSize,
+  workingDays,
 }) {
   const nameDoBFieldPrefix = isGroup ? 'group.head' : 'individual';
   const locationFieldPrefix = isGroup ? 'group' : 'individual';
@@ -249,6 +298,7 @@ function BeneficiaryTable({
   ] : [];
 
   const columns = useMemo(() => {
+    const workDayColumns = getWorkDayColumns(translate, workingDays);
     const allColumns = [
       ...additionalColumns || [],
       {
@@ -274,6 +324,7 @@ function BeneficiaryTable({
         },
       })),
       ...dynamicColumns,
+      ...workDayColumns,
     ];
 
     return allColumns.map((c) => ({

--- a/src/components/BeneficiaryTable.js
+++ b/src/components/BeneficiaryTable.js
@@ -199,7 +199,7 @@ function TableContainer({ children, className }) {
   );
 }
 
-const getWorkDayColumns = (translateFn, workingDays = 0, onTimeEntryChange) => {
+const getWorkDayColumns = (translateFn, onTimeEntryChange, workingDays = 0) => {
   if (!workingDays) return [];
   return Array.from({ length: workingDays }, (_, i) => {
     const dayNumber = i + 1;
@@ -215,6 +215,7 @@ const getWorkDayColumns = (translateFn, workingDays = 0, onTimeEntryChange) => {
       },
       filterComponent: NumberFilter,
       editComponent: (props) => (
+        // eslint-disable-next-line react/jsx-props-no-spreading
         <PercentageEditField {...props} onTimeEntryChange={onTimeEntryChange} dayKey={dayKey} />
       ),
       customFilterAndSearch: createNumericFilterFn(
@@ -349,7 +350,7 @@ function BeneficiaryTable({
         defaultSort: 'asc',
       },
     ] : [];
-    const workDayColumns = getWorkDayColumns(translate, workingDays, onTimeEntryChange);
+    const workDayColumns = getWorkDayColumns(translate, onTimeEntryChange, workingDays);
     const allColumns = [
       ...additionalColumns,
       {

--- a/src/components/BeneficiaryTable.js
+++ b/src/components/BeneficiaryTable.js
@@ -425,9 +425,7 @@ function BeneficiaryTable({
           doubleHorizontalScroll: true,
           tableLayout: 'fixed',
           emptyRowsWhenPaging: false,
-          ...(tableRef?.current?.dataManager?.bulkEditOpen
-            ? { fixedColumns: { left: isGroup ? 3 : 2, right: 0 } }
-            : { fixedColumns: {} }),
+          fixedColumns: { left: isGroup ? 3 : 2, right: 0 },
           actionsColumnIndex: -1,
         }}
         localization={{

--- a/src/components/BeneficiaryTable.js
+++ b/src/components/BeneficiaryTable.js
@@ -1,4 +1,6 @@
-import React, { useMemo, useEffect, useRef, useCallback } from 'react';
+import React, {
+  useMemo, useEffect, useRef, useCallback,
+} from 'react';
 import { injectIntl } from 'react-intl';
 import MaterialTable from 'material-table';
 import _ from 'lodash';
@@ -36,7 +38,7 @@ const styles = (theme) => ({
   paper: theme.paper.classes,
   containerWrapper: {
     padding: '0 20px',
-    // Patch style of a nested matertial-table element
+    // Patch style of a nested material-table element
     // so frozen columns work correctly
     '& > div:nth-child(2) > div:nth-child(2)': {
       position: 'relative',
@@ -161,15 +163,24 @@ function PercentageEditField({ value, onChange }) {
       type="number"
       value={numValue}
       onChange={(e) => onChange(e.target.value)}
-      inputProps={{ min: 0, max: 100 }}
       error={isInvalid}
       helperText={isInvalid ? '0-100' : ''}
       InputProps={{
+        min: 0,
+        max: 100,
         endAdornment: <InputAdornment position="end">%</InputAdornment>,
       }}
       style={{ width: '80px' }}
       size="small"
     />
+  );
+}
+
+function TableContainer({ children, className }) {
+  return (
+    <Paper elevation={2} className={className}>
+      {children}
+    </Paper>
   );
 }
 
@@ -186,9 +197,7 @@ const getWorkDayColumns = (translateFn, workingDays = 0) => {
         return value !== undefined && value !== null ? `${value}%` : '';
       },
       filterComponent: NumberFilter,
-      editComponent: (props) => (
-        <PercentageEditField value={props.value} onChange={props.onChange} />
-      ),
+      editComponent: PercentageEditField,
       customFilterAndSearch: (filter, rowData) => {
         const value = rowData.projectTimeEntriesDict?.[`day${dayNumber}`]?.percentComplete;
         const numValue = (value === null || value === undefined) ? 0 : Number(value);
@@ -380,16 +389,20 @@ function BeneficiaryTable({
 
   const cellPadding = isSelectable ? '0' : DEFAULT_CELL_PADDING;
 
+  const ContainerComponent = useCallback(
+    (props) => <TableContainer className={classes.containerWrapper}>{props.children}</TableContainer>,
+    [classes.containerWrapper],
+  );
+
+  const tableComponents = useMemo(
+    () => ({ Container: ContainerComponent }),
+    [ContainerComponent],
+  );
+
   return (
     <ThemeProvider theme={tableTheme}>
       <MaterialTable
-        components={{
-          Container: (props) => (
-            <Paper elevation={2} className={classes.containerWrapper}>
-              {props.children}
-            </Paper>
-          ),
-        }}
+        components={tableComponents}
         title={tableTitle}
         columns={columns}
         data={onQueryChange || allRows}

--- a/src/components/BenefitPlanGroupBeneficiariesFilter.js
+++ b/src/components/BenefitPlanGroupBeneficiariesFilter.js
@@ -1,8 +1,9 @@
 import React from 'react';
-import { injectIntl } from 'react-intl';
 import { Grid } from '@material-ui/core';
 import { withTheme, withStyles } from '@material-ui/core/styles';
-import { formatMessage, TextInput, ConstantBasedPicker, PublishedComponent } from '@openimis/fe-core';
+import {
+  TextInput, ConstantBasedPicker, PublishedComponent,
+} from '@openimis/fe-core';
 import _debounce from 'lodash/debounce';
 import { defaultFilterStyles } from '../util/styles';
 import BeneficiaryStatusPicker from '../pickers/BeneficiaryStatusPicker';

--- a/src/components/BenefitPlanProjectsSearcher.js
+++ b/src/components/BenefitPlanProjectsSearcher.js
@@ -291,8 +291,6 @@ function BenefitPlanProjectsSearcher({
         searcherActions={searcherActions}
         enableActionButtons
         searcherActionsPosition="header-right"
-        exportable
-        exportFieldLabel={formatMessage(intl, MODULE_NAME, 'export.label')}
         onDoubleClick={openProject}
         onFiltersApplied={onFiltersApplied}
       />

--- a/src/components/MaterialTableNumberFilter.js
+++ b/src/components/MaterialTableNumberFilter.js
@@ -7,6 +7,7 @@ import {
   Popover,
   MenuItem,
 } from '@material-ui/core';
+import ClearIcon from '@material-ui/icons/Clear';
 import {
   formatMessage,
 } from '@openimis/fe-core';
@@ -26,15 +27,25 @@ function NumberFilter({ intl, columnDef, onFilterChanged }) {
   const handleOperatorClose = (selectedOperator) => {
     setAnchorEl(null);
     if (selectedOperator) {
-      const newOperator = selectedOperator;
-      setOperator(newOperator);
-      const newFilter = {
-        ...columnDef.tableData.filterValue,
-        operator: newOperator,
-      };
-      onFilterChanged(columnDef.tableData.id, newFilter);
+      setOperator(selectedOperator);
+      const currentValue = columnDef.tableData.filterValue?.value;
+      if (currentValue !== undefined && currentValue !== '') {
+        onFilterChanged(columnDef.tableData.id, {
+          value: currentValue,
+          operator: selectedOperator,
+        });
+      }
     }
   };
+
+  const handleClear = () => {
+    setOperator('exact');
+    onFilterChanged(columnDef.tableData.id, undefined);
+  };
+
+  const hasValue = (columnDef.tableData.filterValue?.value !== undefined
+    && columnDef.tableData.filterValue?.value !== '')
+    || operator !== 'exact';
 
   const operatorIcon = () => {
     switch (operator) {
@@ -54,11 +65,10 @@ function NumberFilter({ intl, columnDef, onFilterChanged }) {
         value={columnDef.tableData.filterValue?.value || ''}
         placeholder={translate('projectBeneficiaries.filterPlaceholder')}
         onChange={(e) => {
-          const newFilter = {
-            ...columnDef.tableData.filterValue,
+          onFilterChanged(columnDef.tableData.id, {
             value: e.target.value,
-          };
-          onFilterChanged(columnDef.tableData.id, newFilter);
+            operator,
+          });
         }}
         InputProps={{
           startAdornment: (
@@ -106,6 +116,17 @@ function NumberFilter({ intl, columnDef, onFilterChanged }) {
               </Popover>
             </InputAdornment>
           ),
+          endAdornment: hasValue ? (
+            <InputAdornment position="end">
+              <IconButton
+                size="small"
+                onClick={handleClear}
+                style={{ padding: '4px' }}
+              >
+                <ClearIcon style={{ fontSize: '16px' }} />
+              </IconButton>
+            </InputAdornment>
+          ) : null,
         }}
       />
     </div>

--- a/src/components/ProjectBeneficiaryTable.js
+++ b/src/components/ProjectBeneficiaryTable.js
@@ -22,6 +22,10 @@ import {
 } from '../dialogs/ProjectEnrollmentDialog';
 import { REQUEST } from '../util/action-type';
 import { ACTION_TYPE } from '../reducer';
+import {
+  bulkUpdateBeneficiaryTimeEntries,
+  bulkUpdateGroupBeneficiaryTimeEntries,
+} from '../actions';
 
 function BaseProjectBeneficiaryTable({
   project,
@@ -116,15 +120,60 @@ function BaseProjectBeneficiaryTable({
     const isEditing = materialTable.dataManager.bulkEditOpen;
 
     if (isEditing) {
-      // TODO: implement API
-      // const updatedRows = Object.values(materialTable.state.bulkEditChangedRows || {});
-      // if (updatedRows.length > 0) {
-      //   dispatch({
-      //     type: REQUEST(ACTION_TYPE.UPDATE_PROJECT_BENEFICIARIES_PROGRESS),
-      //     payload: updatedRows,
-      //     meta: { projectId: project.id },
-      //   });
-      // }
+      // Save time entries
+      const updatedRows = Object.values(materialTable.dataManager.bulkEditChangedRows || {});
+
+      if (updatedRows.length > 0) {
+        const timeEntries = [];
+
+        updatedRows.forEach(({ newData, oldData }) => {
+          // Compare oldData with newData to find actual changes
+          const newEntries = newData.projectTimeEntriesDict || {};
+          const oldEntries = oldData.projectTimeEntriesDict || {};
+
+          // Get all day keys from both old and new
+          const allDayKeys = new Set([
+            ...Object.keys(newEntries).filter((k) => k.startsWith('day')),
+            ...Object.keys(oldEntries).filter((k) => k.startsWith('day')),
+          ]);
+
+          allDayKeys.forEach((key) => {
+            const dayNumber = parseInt(key.replace('day', ''), 10);
+            const newEntry = newEntries[key];
+            const oldEntry = oldEntries[key];
+
+            const oldPercent = oldEntry?.percentComplete;
+            const newPercent = newEntry?.percentComplete;
+
+            // Normalize new value: empty string, undefined, NaN, null to 0 (0 means no progress/cleared)
+            const normalizedNew = newPercent || 0;
+
+            // Compare raw old value with normalized new value
+            // This handles the case where oldPercent is undefined and we want to set it to 0
+            if (oldPercent !== normalizedNew) {
+              timeEntries.push({
+                id: newEntry?.id || oldEntry?.id || null,
+                [isGroup ? 'groupBeneficiaryId' : 'beneficiaryId']: newData.id,
+                dayNumber,
+                percentComplete: normalizedNew,
+              });
+            }
+          });
+        });
+
+        if (timeEntries.length > 0) {
+          const params = {
+            projectId: project.id,
+            timeEntries,
+          };
+
+          const action = isGroup
+            ? bulkUpdateGroupBeneficiaryTimeEntries(params, 'Update project time entries')
+            : bulkUpdateBeneficiaryTimeEntries(params, 'Update project time entries');
+
+          dispatch(action);
+        }
+      }
     }
 
     const newState = !isEditing;

--- a/src/components/ProjectBeneficiaryTable.js
+++ b/src/components/ProjectBeneficiaryTable.js
@@ -1,5 +1,5 @@
 import React, {
-  useState, useEffect, useRef, useMemo,
+  useState, useEffect, useRef, useMemo, useCallback,
 } from 'react';
 import { injectIntl } from 'react-intl';
 import {
@@ -56,8 +56,40 @@ function BaseProjectBeneficiaryTable({
   );
   const materialTableRef = useRef();
   const [bulkEditOpen, setBulkEditOpen] = useState(false);
+  const [pendingChanges, setPendingChanges] = useState({});
 
   const dispatch = useDispatch();
+
+  const handleTimeEntryChange = useCallback((enrollmentId, dayKey, value, originalEntry, rowData) => {
+    setPendingChanges((prev) => {
+      const existing = prev[enrollmentId];
+      const oldData = existing?.oldData || rowData;
+      const currentNewData = existing?.newData || rowData;
+
+      const newData = {
+        ...currentNewData,
+        projectTimeEntriesDict: {
+          ...currentNewData.projectTimeEntriesDict,
+          [dayKey]: {
+            ...currentNewData.projectTimeEntriesDict?.[dayKey],
+            id: originalEntry?.id,
+            percentComplete: value,
+          },
+        },
+      };
+
+      return {
+        ...prev,
+        [enrollmentId]: { oldData, newData },
+      };
+    });
+  }, []);
+
+  const mergedBeneficiaries = useMemo(() => beneficiaries.map((row) => {
+    const changes = pendingChanges[row.enrollmentId];
+    if (!changes?.newData) return row;
+    return changes.newData;
+  }), [beneficiaries, pendingChanges]);
   // Trigger fetch: batch & concat handled in projectBeneficiariesMiddleware & reducers
   useEffect(() => {
     if (project?.benefitPlan?.id) {
@@ -125,80 +157,74 @@ function BaseProjectBeneficiaryTable({
     const isEditing = materialTable.dataManager.bulkEditOpen;
 
     if (isEditing) {
-      // Save time entries
-      const updatedRows = Object.values(materialTable.dataManager.bulkEditChangedRows || {});
+      const bulkEditRows = Object.values(materialTable.dataManager.bulkEditChangedRows || {});
+      const processedIds = new Set(bulkEditRows.map(({ newData }) => newData.enrollmentId));
 
-      if (updatedRows.length > 0) {
-        const timeEntries = [];
+      // Merge MaterialTable's tracked changes from bulkEditRows
+      // with pendingChanges tracking rows edited the filtered out
+      const pendingRows = Object.values(pendingChanges)
+        .filter(({ newData }) => !processedIds.has(newData.enrollmentId));
+      const allChangedRows = [...bulkEditRows, ...pendingRows];
 
-        updatedRows.forEach(({ newData, oldData }) => {
-          // Compare oldData with newData to find actual changes
-          const newEntries = newData.projectTimeEntriesDict || {};
-          const oldEntries = oldData.projectTimeEntriesDict || {};
+      const timeEntries = [];
+      allChangedRows.forEach(({ newData, oldData }) => {
+        const newEntries = newData.projectTimeEntriesDict || {};
+        const oldEntries = oldData.projectTimeEntriesDict || {};
 
-          // Get all day keys from both old and new
-          const allDayKeys = new Set([
-            ...Object.keys(newEntries).filter((k) => k.startsWith('day')),
-            ...Object.keys(oldEntries).filter((k) => k.startsWith('day')),
-          ]);
+        const allDayKeys = new Set([
+          ...Object.keys(newEntries).filter((k) => k.startsWith('day')),
+          ...Object.keys(oldEntries).filter((k) => k.startsWith('day')),
+        ]);
 
-          allDayKeys.forEach((key) => {
-            const dayNumber = parseInt(key.replace('day', ''), 10);
-            const newEntry = newEntries[key];
-            const oldEntry = oldEntries[key];
+        allDayKeys.forEach((dayKey) => {
+          const newEntry = newEntries[dayKey];
+          const oldEntry = oldEntries[dayKey];
+          const oldPercent = oldEntry?.percentComplete;
+          const newPercent = newEntry?.percentComplete;
 
-            const oldPercent = oldEntry?.percentComplete;
-            const newPercent = newEntry?.percentComplete;
+          const normalizedNew = newPercent === '' || newPercent === undefined || newPercent === null
+            ? 0
+            : Number(newPercent);
 
-            // Normalize: empty string, undefined, NaN, null to 0
-            const normalizedNew = newPercent === '' || newPercent === undefined || newPercent === null
-              ? 0
-              : Number(newPercent);
-
-            // Compare raw old value with normalized new value
-            // This handles the case where oldPercent is undefined and we want to set it to 0
-            if (oldPercent !== normalizedNew) {
-              timeEntries.push({
-                id: newEntry?.id || oldEntry?.id || null,
-                enrollmentId: newData.enrollmentId,
-                dayNumber,
-                percentComplete: normalizedNew,
-              });
-            }
-          });
+          if (oldPercent !== normalizedNew) {
+            timeEntries.push({
+              id: newEntry?.id || oldEntry?.id || null,
+              enrollmentId: newData.enrollmentId,
+              dayNumber: parseInt(dayKey.replace('day', ''), 10),
+              percentComplete: normalizedNew,
+            });
+          }
         });
+      });
 
-        const invalidEntries = timeEntries.filter(
-          (entry) => entry.percentComplete < 0 || entry.percentComplete > 100,
+      const hasInvalidEntries = timeEntries.some(
+        (e) => e.percentComplete < 0 || e.percentComplete > 100,
+      );
+
+      if (hasInvalidEntries) {
+        showAlert(
+          formatMessage(intl, MODULE_NAME, 'projectBeneficiaries.timeEntry.validation.title'),
+          formatMessage(intl, MODULE_NAME, 'projectBeneficiaries.timeEntry.validation.message'),
+        );
+        return;
+      }
+
+      if (timeEntries.length > 0) {
+        const mutationLabel = formatMessageWithValues(
+          intl,
+          MODULE_NAME,
+          'projectBeneficiaries.timeEntry.mutationLabel',
+          { n: timeEntries.length, name: project.name },
         );
 
-        if (invalidEntries.length > 0) {
-          showAlert(
-            formatMessage(intl, MODULE_NAME, 'projectBeneficiaries.timeEntry.validation.title'),
-            formatMessage(intl, MODULE_NAME, 'projectBeneficiaries.timeEntry.validation.message'),
-          );
-          return;
-        }
+        const action = isGroup
+          ? bulkUpdateGroupBeneficiaryTimeEntries({ timeEntries }, mutationLabel)
+          : bulkUpdateBeneficiaryTimeEntries({ timeEntries }, mutationLabel);
 
-        if (timeEntries.length > 0) {
-          const params = {
-            timeEntries,
-          };
-
-          const mutationLabel = formatMessageWithValues(
-            intl,
-            MODULE_NAME,
-            'projectBeneficiaries.timeEntry.mutationLabel',
-            { n: timeEntries.length, name: project.name },
-          );
-
-          const action = isGroup
-            ? bulkUpdateGroupBeneficiaryTimeEntries(params, mutationLabel)
-            : bulkUpdateBeneficiaryTimeEntries(params, mutationLabel);
-
-          dispatch(action);
-        }
+        dispatch(action);
       }
+
+      setPendingChanges({});
     }
 
     const newState = !isEditing;
@@ -209,7 +235,6 @@ function BaseProjectBeneficiaryTable({
     setBulkEditOpen(newState);
 
     if (newState) {
-      // Allow the DOM to re-render the editable cells first
       setTimeout(() => {
         scrollToFirstWorkingDayColumn();
       }, 300);
@@ -233,6 +258,7 @@ function BaseProjectBeneficiaryTable({
       ...materialTable.dataManager.getRenderState(),
     });
     setBulkEditOpen(false);
+    setPendingChanges({});
   };
 
   function getTableActions() {
@@ -269,13 +295,14 @@ function BaseProjectBeneficiaryTable({
     !!project?.id && (
       <>
         <BeneficiaryTable
-          allRows={beneficiaries}
+          allRows={mergedBeneficiaries}
           fetchingBeneficiaries={fetchingBeneficiaries}
           tableTitle={tableTitle}
           isGroup={isGroup}
           actions={actions}
           workingDays={project.workingDays}
           tableRef={materialTableRef}
+          onTimeEntryChange={handleTimeEntryChange}
         />
         <EnrollmentDialogComponent
           open={enrollmentDialogOpen}

--- a/src/components/ProjectBeneficiaryTable.js
+++ b/src/components/ProjectBeneficiaryTable.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef, useMemo } from 'react';
 import { injectIntl } from 'react-intl';
 import {
   formatMessage,
@@ -45,6 +45,8 @@ function BaseProjectBeneficiaryTable({
     'projectBeneficiaries.enrolled',
     { n: beneficiariesTotalCount },
   );
+  const materialTableRef = useRef();
+  const [bulkEditOpen, setBulkEditOpen] = useState(false);
 
   const dispatch = useDispatch();
   // Trigger fetch: batch & concat handled in projectBeneficiariesMiddleware & reducers
@@ -70,13 +72,124 @@ function BaseProjectBeneficiaryTable({
     </Button>
   );
 
-  const actions = rights.includes(RIGHT_PROJECT_UPDATE) ? [
-    {
-      icon: assignButtonComponentFn,
-      isFreeAction: true,
-      onClick: () => setEnrollmentDialogOpen(true),
-    },
-  ] : [];
+  const enterTimeComponentFn = () => {
+    const isEditing = materialTableRef.current?.dataManager?.bulkEditOpen;
+
+    return (
+      <Button
+        variant="contained"
+        color="primary"
+      >
+        <Typography variant="body2">
+          {isEditing
+            ? formatMessage(intl, MODULE_NAME, 'projectBeneficiaries.saveTime')
+            : formatMessage(intl, MODULE_NAME, 'projectBeneficiaries.enterTime')}
+        </Typography>
+      </Button>
+    );
+  };
+
+  function scrollToFirstWorkingDayColumn() {
+    const scrollContainer = materialTableRef.current?.tableContainerDiv?.current;
+    if (!scrollContainer) return;
+
+    const headerCells = scrollContainer.querySelectorAll('thead th');
+    const firstDayTitle = `${formatMessage(intl, MODULE_NAME, 'project.day')} 1`;
+    const targetHeader = Array.from(headerCells).find((th) => th.textContent.includes(firstDayTitle));
+
+    if (targetHeader) {
+      const numFrozenCols = isGroup ? 3 : 2;
+      const frozenColumns = Array.from(headerCells).slice(0, numFrozenCols);
+      const frozenWidth = frozenColumns.reduce((sum, th) => sum + th.offsetWidth, 0);
+
+      scrollContainer.scrollTo({
+        left: targetHeader.offsetLeft - frozenWidth,
+        behavior: 'smooth',
+      });
+    }
+  }
+
+  const handleToggleEdit = () => {
+    const materialTable = materialTableRef.current;
+    if (!materialTable?.dataManager) return;
+
+    const isEditing = materialTable.dataManager.bulkEditOpen;
+
+    if (isEditing) {
+      // TODO: implement API
+      // const updatedRows = Object.values(materialTable.state.bulkEditChangedRows || {});
+      // if (updatedRows.length > 0) {
+      //   dispatch({
+      //     type: REQUEST(ACTION_TYPE.UPDATE_PROJECT_BENEFICIARIES_PROGRESS),
+      //     payload: updatedRows,
+      //     meta: { projectId: project.id },
+      //   });
+      // }
+    }
+
+    const newState = !isEditing;
+    materialTable.dataManager.changeBulkEditOpen(newState);
+    materialTable.setState({
+      ...materialTable.dataManager.getRenderState(),
+    });
+    setBulkEditOpen(newState);
+
+    if (newState) {
+      // Allow the DOM to re-render the editable cells first
+      setTimeout(() => {
+        scrollToFirstWorkingDayColumn();
+      }, 300);
+    }
+  };
+
+  const cancelEditButtonFn = () => (
+    <Button variant="outlined" color="default">
+      <Typography variant="body2">
+        {formatMessage(intl, MODULE_NAME, 'projectBeneficiaries.cancelEdit')}
+      </Typography>
+    </Button>
+  );
+
+  const handleCancelEdit = () => {
+    const materialTable = materialTableRef.current;
+    if (!materialTable?.dataManager) return;
+
+    materialTable.dataManager.changeBulkEditOpen(false);
+    materialTable.setState({
+      ...materialTable.dataManager.getRenderState(),
+    });
+    setBulkEditOpen(false);
+  };
+
+  function getTableActions() {
+    if (!rights.includes(RIGHT_PROJECT_UPDATE)) return [];
+
+    const materialTable = materialTableRef.current;
+    const tableActions = [
+      {
+        icon: assignButtonComponentFn,
+        isFreeAction: true,
+        onClick: () => setEnrollmentDialogOpen(true),
+      },
+      {
+        icon: enterTimeComponentFn,
+        isFreeAction: true,
+        onClick: handleToggleEdit,
+      },
+    ];
+
+    if (materialTable?.dataManager?.bulkEditOpen) {
+      tableActions.push({
+        icon: cancelEditButtonFn,
+        isFreeAction: true,
+        onClick: handleCancelEdit,
+      });
+    }
+
+    return tableActions;
+  }
+
+  const actions = useMemo(getTableActions, [rights, bulkEditOpen]);
 
   return (
     !!project?.id && (
@@ -88,6 +201,7 @@ function BaseProjectBeneficiaryTable({
           isGroup={isGroup}
           actions={actions}
           workingDays={project.workingDays}
+          tableRef={materialTableRef}
         />
         <EnrollmentDialogComponent
           open={enrollmentDialogOpen}

--- a/src/components/ProjectBeneficiaryTable.js
+++ b/src/components/ProjectBeneficiaryTable.js
@@ -85,7 +85,7 @@ function BaseProjectBeneficiaryTable({
     });
   }, []);
 
-  const mergedBeneficiaries = useMemo(() => beneficiaries.map((row) => {
+  const mergedBeneficiaries = useMemo(() => beneficiaries||[].map((row) => {
     const changes = pendingChanges[row.enrollmentId];
     if (!changes?.newData) return row;
     return changes.newData;

--- a/src/components/ProjectBeneficiaryTable.js
+++ b/src/components/ProjectBeneficiaryTable.js
@@ -160,7 +160,7 @@ function BaseProjectBeneficiaryTable({
             if (oldPercent !== normalizedNew) {
               timeEntries.push({
                 id: newEntry?.id || oldEntry?.id || null,
-                [isGroup ? 'groupBeneficiaryId' : 'beneficiaryId']: newData.id,
+                enrollmentId: newData.enrollmentId,
                 dayNumber,
                 percentComplete: normalizedNew,
               });
@@ -182,13 +182,19 @@ function BaseProjectBeneficiaryTable({
 
         if (timeEntries.length > 0) {
           const params = {
-            projectId: project.id,
             timeEntries,
           };
 
+          const mutationLabel = formatMessageWithValues(
+            intl,
+            MODULE_NAME,
+            'projectBeneficiaries.timeEntry.mutationLabel',
+            { n: timeEntries.length, name: project.name },
+          );
+
           const action = isGroup
-            ? bulkUpdateGroupBeneficiaryTimeEntries(params, 'Update project time entries')
-            : bulkUpdateBeneficiaryTimeEntries(params, 'Update project time entries');
+            ? bulkUpdateGroupBeneficiaryTimeEntries(params, mutationLabel)
+            : bulkUpdateBeneficiaryTimeEntries(params, mutationLabel);
 
           dispatch(action);
         }

--- a/src/components/ProjectBeneficiaryTable.js
+++ b/src/components/ProjectBeneficiaryTable.js
@@ -4,8 +4,10 @@ import {
   formatMessage,
   formatMessageWithValues,
   useModulesManager,
+  coreAlert,
 } from '@openimis/fe-core';
 import { connect, useDispatch } from 'react-redux';
+import { bindActionCreators } from 'redux';
 import {
   Button,
   Typography,
@@ -36,6 +38,7 @@ function BaseProjectBeneficiaryTable({
   fetchingBeneficiaries,
   beneficiaries,
   beneficiariesTotalCount,
+  coreAlert: showAlert,
 }) {
   const orderBy = isGroup ? 'orderBy: ["group__code"]' : 'orderBy: ["individual__last_name", "individual__first_name"]';
   const actionType = isGroup
@@ -145,8 +148,10 @@ function BaseProjectBeneficiaryTable({
             const oldPercent = oldEntry?.percentComplete;
             const newPercent = newEntry?.percentComplete;
 
-            // Normalize new value: empty string, undefined, NaN, null to 0 (0 means no progress/cleared)
-            const normalizedNew = newPercent || 0;
+            // Normalize: empty string, undefined, NaN, null to 0
+            const normalizedNew = newPercent === '' || newPercent === undefined || newPercent === null
+              ? 0
+              : Number(newPercent);
 
             // Compare raw old value with normalized new value
             // This handles the case where oldPercent is undefined and we want to set it to 0
@@ -160,6 +165,18 @@ function BaseProjectBeneficiaryTable({
             }
           });
         });
+
+        const invalidEntries = timeEntries.filter(
+          (entry) => entry.percentComplete < 0 || entry.percentComplete > 100,
+        );
+
+        if (invalidEntries.length > 0) {
+          showAlert(
+            formatMessage(intl, MODULE_NAME, 'projectBeneficiaries.timeEntry.validation.title'),
+            formatMessage(intl, MODULE_NAME, 'projectBeneficiaries.timeEntry.validation.message'),
+          );
+          return;
+        }
 
         if (timeEntries.length > 0) {
           const params = {
@@ -273,8 +290,11 @@ const mapStateToPropsIndividual = (state) => ({
   beneficiariesTotalCount: state.socialProtection.projectBeneficiariesTotalCount,
 });
 
+const mapDispatchToProps = (dispatch) => bindActionCreators({ coreAlert }, dispatch);
+
 const ConnectedProjectBeneficiaryTable = connect(
   mapStateToPropsIndividual,
+  mapDispatchToProps,
 )(BaseProjectBeneficiaryTable);
 
 export const ProjectBeneficiaryTable = injectIntl((props) => (
@@ -294,6 +314,7 @@ const mapStateToPropsGroup = (state) => ({
 
 const ConnectedProjectGroupBeneficiaryTable = connect(
   mapStateToPropsGroup,
+  mapDispatchToProps,
 )(BaseProjectBeneficiaryTable);
 
 export const ProjectGroupBeneficiaryTable = injectIntl((props) => (

--- a/src/components/ProjectBeneficiaryTable.js
+++ b/src/components/ProjectBeneficiaryTable.js
@@ -85,7 +85,7 @@ function BaseProjectBeneficiaryTable({
     });
   }, []);
 
-  const mergedBeneficiaries = useMemo(() => beneficiaries||[].map((row) => {
+  const mergedBeneficiaries = useMemo(() => (beneficiaries || []).map((row) => {
     const changes = pendingChanges[row.enrollmentId];
     if (!changes?.newData) return row;
     return changes.newData;
@@ -334,6 +334,7 @@ const ConnectedProjectBeneficiaryTable = connect(
 
 export const ProjectBeneficiaryTable = injectIntl((props) => (
   <ConnectedProjectBeneficiaryTable
+    // eslint-disable-next-line react/jsx-props-no-spreading
     {...props}
     EnrollmentDialogComponent={ProjectBeneficiariyEnrollmentDialog}
   />
@@ -354,6 +355,7 @@ const ConnectedProjectGroupBeneficiaryTable = connect(
 
 export const ProjectGroupBeneficiaryTable = injectIntl((props) => (
   <ConnectedProjectGroupBeneficiaryTable
+    // eslint-disable-next-line react/jsx-props-no-spreading
     {...props}
     isGroup
     EnrollmentDialogComponent={ProjectGroupBeneficiaryEnrollmentDialog}

--- a/src/components/ProjectBeneficiaryTable.js
+++ b/src/components/ProjectBeneficiaryTable.js
@@ -87,6 +87,7 @@ function BaseProjectBeneficiaryTable({
           tableTitle={tableTitle}
           isGroup={isGroup}
           actions={actions}
+          workingDays={project.workingDays}
         />
         <EnrollmentDialogComponent
           open={enrollmentDialogOpen}

--- a/src/components/ProjectBeneficiaryTable.js
+++ b/src/components/ProjectBeneficiaryTable.js
@@ -1,4 +1,6 @@
-import React, { useState, useEffect, useRef, useMemo } from 'react';
+import React, {
+  useState, useEffect, useRef, useMemo,
+} from 'react';
 import { injectIntl } from 'react-intl';
 import {
   formatMessage,

--- a/src/components/ProjectHeadPanel.js
+++ b/src/components/ProjectHeadPanel.js
@@ -19,6 +19,7 @@ import {
 import ProjectStatusPicker from '../pickers/ProjectStatusPicker';
 import ActivityPicker from '../pickers/ActivityPicker';
 import ProjectAllowsMultiEnrollmentPicker from '../pickers/ProjectAllowsMultiEnrollmentPicker';
+import { DEFAULT_MAX_WORKING_DAYS } from '../constants';
 
 const styles = (theme) => ({
   item: theme.paper.item,
@@ -39,10 +40,12 @@ class ProjectHeadPanel extends FormPanel {
       projectNameValidationError,
       savedProjectName,
       readOnly,
+      modulesManager,
     } = this.props;
 
     const project = { ...edited };
     const isNewProject = !project?.id;
+    const maxWorkingDays = modulesManager.getConf('fe-social_protection', 'maxWorkingDays', DEFAULT_MAX_WORKING_DAYS);
 
     return (
       <Grid container className={classes.item}>
@@ -112,6 +115,7 @@ class ProjectHeadPanel extends FormPanel {
             required
             readOnly={readOnly}
             min={1}
+            max={maxWorkingDays}
             value={project?.workingDays}
             onChange={(v) => this.updateAttribute('workingDays', v)}
           />

--- a/src/constants.js
+++ b/src/constants.js
@@ -2,6 +2,7 @@ export const SOCIAL_PROTECTION_MAIN_MENU_CONTRIBUTION_KEY = 'socialProtection.Ma
 export const CONTAINS_LOOKUP = 'Icontains';
 export const DEFAULT_DEBOUNCE_TIME = 500;
 export const DEFAULT_PAGE_SIZE = 10;
+export const DEFAULT_MAX_WORKING_DAYS = 1000;
 export const EMPTY_STRING = '';
 export const ROWS_PER_PAGE_OPTIONS = [10, 20, 50, 100];
 

--- a/src/dialogs/ProjectEnrollmentDialog.js
+++ b/src/dialogs/ProjectEnrollmentDialog.js
@@ -106,7 +106,7 @@ function ProjectEnrollmentDialog({
       'isDeleted: false',
       'status: ACTIVE',
       `villageOrChildOf: ${decodeId(project.location.id)}`,
-      `projectAllowsMultipleEnrollments: "${project.id}"`,
+      `eligibleForProject: "${project.id}"`,
       `first: ${newPageSize}`,
       `offset: ${offset}`,
     ];

--- a/src/dialogs/ProjectEnrollmentDialog.js
+++ b/src/dialogs/ProjectEnrollmentDialog.js
@@ -192,7 +192,8 @@ function ProjectEnrollmentDialog({
 
     if (orderBy) {
       const prefix = orderDirection === 'desc' ? '-' : '';
-      gqlFilters.push(`orderBy: ["${prefix}${convertFieldName(orderBy.field)}"]`);
+      const fieldName = orderBy.orderField || convertFieldName(orderBy.field);
+      gqlFilters.push(`orderBy: ["${prefix}${fieldName}"]`);
     }
 
     const response = await fetchBeneficiaries(modulesManager, gqlFilters);

--- a/src/index.js
+++ b/src/index.js
@@ -50,6 +50,7 @@ import BenefitPlanSearcherForEntities from './components/BenefitPlanSearcherForE
 import { BenefitPackageMembersTabLabel, BenefitPackageMembersTabPanel } from './components/BenefitPackageMembersTab';
 import BenefitPlanTaskPreviewTable from './components/BenefitPlanTaskPreviewTable';
 import BenefitPlanPicker from './pickers/BenefitPlanPicker';
+import ProjectPicker from './pickers/ProjectPicker';
 import { BenefitPlansListTabLabel, BenefitPlansListTabPanel } from './components/BenefitPlansListTab';
 import {
   BenefitPlanTaskItemFormatters,
@@ -121,6 +122,7 @@ const DEFAULT_CONFIG = {
     { key: 'socialProtection.BenefitPlanSearcherForEntities', ref: BenefitPlanSearcherForEntities },
     { key: 'socialProtection.BenefitPlanTaskPreviewTable', ref: BenefitPlanTaskPreviewTable },
     { key: 'socialProtection.BenefitPlanPicker', ref: BenefitPlanPicker },
+    { key: 'socialProtection.ProjectPicker', ref: ProjectPicker },
     { key: 'socialProtection.BenefitPlansListTabLabel', ref: BenefitPlansListTabLabel },
     { key: 'socialProtection.BenefitPlansListTabPanel', ref: BenefitPlansListTabPanel },
     { key: 'socialProtection.fetchBenefitPlanSchemaFields', ref: fetchBenefitPlanSchemaFields },

--- a/src/middlewares.js
+++ b/src/middlewares.js
@@ -37,7 +37,7 @@ const projectBeneficiariesMiddleware = (store) => (next) => (action) => {
     const payloadField = isGroup ? 'groupBeneficiary' : 'beneficiary';
 
     const params = [
-      `project_Id: "${fetchAllForProjectId}"`,
+      `enrolledInProject: "${fetchAllForProjectId}"`,
       'isDeleted: false',
       orderBy,
       `first: ${batchSize}`,

--- a/src/pickers/ProjectPicker.js
+++ b/src/pickers/ProjectPicker.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { TextField, Tooltip } from '@material-ui/core';
+import { TextField } from '@material-ui/core';
 import {
   Autocomplete,
   useGraphqlQuery,
@@ -113,15 +113,13 @@ function ProjectPicker({
         isDeleted: false,
       })}
       renderInput={(inputProps) => (
-        <Tooltip title="">
-          <TextField
-            /* eslint-disable-next-line react/jsx-props-no-spreading */
-            {...inputProps}
-            required={required}
-            label={(withLabel && label) || formatMessage('project.picker.label')}
-            placeholder={placeholderStr}
-          />
-        </Tooltip>
+        <TextField
+          /* eslint-disable-next-line react/jsx-props-no-spreading */
+          {...inputProps}
+          required={required}
+          label={(withLabel && label) || formatMessage('project.picker.label')}
+          placeholder={placeholderStr}
+        />
       )}
     />
   );

--- a/src/pickers/ProjectPicker.js
+++ b/src/pickers/ProjectPicker.js
@@ -1,0 +1,130 @@
+import React, { useState, useEffect } from 'react';
+import { TextField, Tooltip } from '@material-ui/core';
+import {
+  Autocomplete,
+  useGraphqlQuery,
+  useModulesManager,
+  useTranslations,
+  decodeId,
+} from '@openimis/fe-core';
+
+function ProjectPicker({
+  benefitPlanId,
+  status,
+  multiple = true,
+  required = false,
+  label,
+  withLabel = true,
+  placeholder,
+  withPlaceholder = true,
+  readOnly = false,
+  value,
+  onChange,
+  filter,
+  filterSelectedOptions,
+}) {
+  const modulesManager = useModulesManager();
+  const { formatMessage } = useTranslations('socialProtection', modulesManager);
+
+  const [filters, setFilters] = useState({
+    benefitPlan_Id: benefitPlanId,
+    status,
+    isDeleted: false,
+  });
+
+  useEffect(() => {
+    setFilters((prev) => ({
+      ...prev,
+      benefitPlan_Id: benefitPlanId,
+      status,
+    }));
+  }, [benefitPlanId, status]);
+
+  const { isLoading, data, error } = useGraphqlQuery(
+    `
+    query ProjectPicker(
+      $search: String, $first: Int, $benefitPlan_Id: ID, $status: ProjectStatus, $isDeleted: Boolean
+    ) {
+      project(
+        name_Icontains: $search,
+        first: $first,
+        benefitPlan_Id: $benefitPlan_Id,
+        status: $status,
+        isDeleted: $isDeleted,
+        orderBy: "name"
+      ) {
+        edges {
+          node {
+            id
+            name
+            status
+          }
+        }
+      }
+    }
+    `,
+    filters,
+    { skip: !benefitPlanId },
+  );
+
+  const projects = data?.project?.edges?.map((edge) => ({
+    ...edge.node,
+    id: decodeId(edge.node.id),
+  })) ?? [];
+
+  const normalizedValue = React.useMemo(() => {
+    if (!value) return multiple ? [] : null;
+
+    if (multiple && Array.isArray(value)) {
+      return value.map((item) => {
+        if (item.name) return item;
+        return projects.find((p) => p.id === item.id) || item;
+      }).filter(Boolean);
+    }
+
+    if (!multiple) {
+      if (value.name) return value;
+      return projects.find((p) => p.id === value.id) || value;
+    }
+
+    return value;
+  }, [value, projects, multiple]);
+
+  const placeholderStr = readOnly
+    ? ''
+    : (withPlaceholder && placeholder) || formatMessage('project.picker.placeholder');
+
+  return (
+    <Autocomplete
+      multiple={multiple}
+      error={error}
+      readOnly={readOnly || !benefitPlanId}
+      options={projects}
+      isLoading={isLoading}
+      value={normalizedValue}
+      getOptionLabel={(option) => option.name ?? ''}
+      onChange={(v) => onChange?.(v)}
+      filterOptions={filter}
+      filterSelectedOptions={filterSelectedOptions}
+      onInputChange={(search) => setFilters({
+        search,
+        benefitPlan_Id: benefitPlanId,
+        status,
+        isDeleted: false,
+      })}
+      renderInput={(inputProps) => (
+        <Tooltip title="">
+          <TextField
+            /* eslint-disable-next-line react/jsx-props-no-spreading */
+            {...inputProps}
+            required={required}
+            label={(withLabel && label) || formatMessage('project.picker.label')}
+            placeholder={placeholderStr}
+          />
+        </Tooltip>
+      )}
+    />
+  );
+}
+
+export default ProjectPicker;

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -277,12 +277,19 @@ function reducer(
       };
     case SUCCESS(ACTION_TYPE.SEARCH_PROJECT_BENEFICIARIES):
       /* eslint-disable no-case-declarations */
-      const parsedBeneficiaries = parseData(action.payload.data.beneficiary)?.map((beneficiary) => ({
-        ...beneficiary,
-        project: { id: beneficiary?.project?.id ? decodeId(beneficiary.project.id) : null },
-        jsonExt: typeof beneficiary.jsonExt === 'string' ? JSON.parse(beneficiary.jsonExt) : beneficiary.jsonExt,
-        id: decodeId(beneficiary.id),
-      }));
+      const parsedBeneficiaries = parseData(action.payload.data.beneficiary)?.map((beneficiary) => {
+        const projectTimeEntriesDict = {}; // dict from array for bulk edit in material-table
+        (beneficiary.projectTimeEntries || []).forEach((entry) => {
+          projectTimeEntriesDict[`day${entry.dayNumber}`] = entry;
+        });
+        return {
+          ...beneficiary,
+          project: { id: beneficiary?.project?.id ? decodeId(beneficiary.project.id) : null },
+          jsonExt: typeof beneficiary.jsonExt === 'string' ? JSON.parse(beneficiary.jsonExt) : beneficiary.jsonExt,
+          id: decodeId(beneficiary.id),
+          projectTimeEntriesDict,
+        };
+      });
       return {
         ...state,
         fetchingProjectBeneficiaries: false,
@@ -386,6 +393,10 @@ function reducer(
     case SUCCESS(ACTION_TYPE.SEARCH_PROJECT_GROUP_BENEFICIARIES):
       /* eslint-disable no-case-declarations */
       const parsedGroupBeneficiaries = parseData(action.payload.data.groupBeneficiary)?.map((groupBeneficiary) => {
+        const projectTimeEntriesDict = {}; // dict from array for bulk edit in material-table
+        (groupBeneficiary.projectTimeEntries || []).forEach((entry) => {
+          projectTimeEntriesDict[`day${entry.dayNumber}`] = entry;
+        });
         const response = ({
           ...groupBeneficiary,
           project: { id: groupBeneficiary?.project?.id ? decodeId(groupBeneficiary.project.id) : null },
@@ -393,6 +404,7 @@ function reducer(
             ? JSON.parse(groupBeneficiary.jsonExt)
             : groupBeneficiary.jsonExt,
           id: decodeId(groupBeneficiary.id),
+          projectTimeEntriesDict,
         });
         if (response?.group?.id) {
           response.group = ({

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -280,8 +280,10 @@ function reducer(
     case SUCCESS(ACTION_TYPE.SEARCH_PROJECT_BENEFICIARIES):
       /* eslint-disable no-case-declarations */
       const parsedBeneficiaries = parseData(action.payload.data.beneficiary)?.map((beneficiary) => {
-        const projectTimeEntriesDict = {}; // dict from array for bulk edit in material-table
-        (beneficiary.projectTimeEntries || []).forEach((entry) => {
+        const projectTimeEntriesDict = {};
+        const enrollment = beneficiary.projectEnrollments?.[0];
+        const timeEntries = enrollment?.timeEntries || [];
+        timeEntries.forEach((entry) => {
           projectTimeEntriesDict[`day${entry.dayNumber}`] = {
             ...entry,
             id: entry.id ? decodeId(entry.id) : null,
@@ -289,7 +291,8 @@ function reducer(
         });
         return {
           ...beneficiary,
-          project: { id: beneficiary?.project?.id ? decodeId(beneficiary.project.id) : null },
+          enrollmentId: enrollment?.id ? decodeId(enrollment.id) : null,
+          project: { id: enrollment?.project?.id ? decodeId(enrollment.project.id) : null },
           jsonExt: typeof beneficiary.jsonExt === 'string' ? JSON.parse(beneficiary.jsonExt) : beneficiary.jsonExt,
           id: decodeId(beneficiary.id),
           projectTimeEntriesDict,
@@ -398,8 +401,10 @@ function reducer(
     case SUCCESS(ACTION_TYPE.SEARCH_PROJECT_GROUP_BENEFICIARIES):
       /* eslint-disable no-case-declarations */
       const parsedGroupBeneficiaries = parseData(action.payload.data.groupBeneficiary)?.map((groupBeneficiary) => {
-        const projectTimeEntriesDict = {}; // dict from array for bulk edit in material-table
-        (groupBeneficiary.projectTimeEntries || []).forEach((entry) => {
+        const projectTimeEntriesDict = {};
+        const groupEnrollment = groupBeneficiary.projectEnrollments?.[0];
+        const groupTimeEntries = groupEnrollment?.timeEntries || [];
+        groupTimeEntries.forEach((entry) => {
           projectTimeEntriesDict[`day${entry.dayNumber}`] = {
             ...entry,
             id: entry.id ? decodeId(entry.id) : null,
@@ -407,7 +412,8 @@ function reducer(
         });
         const response = ({
           ...groupBeneficiary,
-          project: { id: groupBeneficiary?.project?.id ? decodeId(groupBeneficiary.project.id) : null },
+          enrollmentId: groupEnrollment?.id ? decodeId(groupEnrollment.id) : null,
+          project: { id: groupEnrollment?.project?.id ? decodeId(groupEnrollment.project.id) : null },
           jsonExt: typeof groupBeneficiary.jsonExt === 'string'
             ? JSON.parse(groupBeneficiary.jsonExt)
             : groupBeneficiary.jsonExt,

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -57,6 +57,8 @@ export const ACTION_TYPE = {
   PROJECT_NAME_SET_VALID: 'PROJECT_NAME_SET_VALID',
   PROJECT_ENROLL: 'PROJECT_ENROLL',
   PROJECT_ENROLL_GROUP: 'PROJECT_ENROLL_GROUP',
+  BULK_UPDATE_BENEFICIARY_TIME_ENTRIES: 'BULK_UPDATE_BENEFICIARY_TIME_ENTRIES',
+  BULK_UPDATE_GROUP_BENEFICIARY_TIME_ENTRIES: 'BULK_UPDATE_GROUP_BENEFICIARY_TIME_ENTRIES',
 };
 
 function reducer(
@@ -280,7 +282,10 @@ function reducer(
       const parsedBeneficiaries = parseData(action.payload.data.beneficiary)?.map((beneficiary) => {
         const projectTimeEntriesDict = {}; // dict from array for bulk edit in material-table
         (beneficiary.projectTimeEntries || []).forEach((entry) => {
-          projectTimeEntriesDict[`day${entry.dayNumber}`] = entry;
+          projectTimeEntriesDict[`day${entry.dayNumber}`] = {
+            ...entry,
+            id: entry.id ? decodeId(entry.id) : null,
+          };
         });
         return {
           ...beneficiary,
@@ -395,7 +400,10 @@ function reducer(
       const parsedGroupBeneficiaries = parseData(action.payload.data.groupBeneficiary)?.map((groupBeneficiary) => {
         const projectTimeEntriesDict = {}; // dict from array for bulk edit in material-table
         (groupBeneficiary.projectTimeEntries || []).forEach((entry) => {
-          projectTimeEntriesDict[`day${entry.dayNumber}`] = entry;
+          projectTimeEntriesDict[`day${entry.dayNumber}`] = {
+            ...entry,
+            id: entry.id ? decodeId(entry.id) : null,
+          };
         });
         const response = ({
           ...groupBeneficiary,
@@ -1003,6 +1011,10 @@ function reducer(
       return dispatchMutationResp(state, 'enrollProject', action);
     case SUCCESS(ACTION_TYPE.PROJECT_ENROLL_GROUP):
       return dispatchMutationResp(state, 'enrollGroupProject', action);
+    case SUCCESS(ACTION_TYPE.BULK_UPDATE_BENEFICIARY_TIME_ENTRIES):
+      return dispatchMutationResp(state, 'bulkUpdateBeneficiaryTimeEntries', action);
+    case SUCCESS(ACTION_TYPE.BULK_UPDATE_GROUP_BENEFICIARY_TIME_ENTRIES):
+      return dispatchMutationResp(state, 'bulkUpdateGroupBeneficiaryTimeEntries', action);
     case SUCCESS(ACTION_TYPE.RESOLVE_TASK):
       return dispatchMutationResp(state, 'resolveTask', action);
     case REQUEST(ACTION_TYPE.TASK_MUTATION):

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -246,7 +246,8 @@
       "validation": {
         "title": "Invalid Time Entry",
         "message": "Percentage values must be between 0 and 100. Please correct the highlighted fields before saving."
-      }
+      },
+      "mutationLabel": "Saved {n} time entries for project {name}"
     }
   },
   "common": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -220,8 +220,9 @@
     "searcherResultsTitleHistory": "{projectsHistoryTotalCount} Historical Records Found",
     "version": "Version",
     "dateUpdated": "Date Updated",
-    "userUpdated": "User Updated"
-  },
+    "userUpdated": "User Updated",
+    "day": "Work Day"
+    },
   "projectChangelog": {
     "label": "Changelog"
   },

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -241,7 +241,13 @@
     "enrolled": "{n} Beneficiaries Assigned",
     "enterTime": "Enter time",
     "saveTime": "Save",
-    "cancelEdit": "Cancel"
+    "cancelEdit": "Cancel",
+    "timeEntry": {
+      "validation": {
+        "title": "Invalid Time Entry",
+        "message": "Percentage values must be between 0 and 100. Please correct the highlighted fields before saving."
+      }
+    }
   },
   "common": {
     "true": "Yes",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -234,7 +234,10 @@
     "save": "Save",
     "filterPlaceholder": "Filter...",
     "activeSelected": "{n} active beneficiaries selected",
-    "enrolled": "{n} Beneficiaries Assigned"
+    "enrolled": "{n} Beneficiaries Assigned",
+    "enterTime": "Enter time",
+    "saveTime": "Save",
+    "cancelEdit": "Cancel"
   },
   "common": {
     "true": "Yes",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -188,6 +188,10 @@
   "socialProtection.project.statusPicker.COMPLETED": "Completed",
   "socialProtection.project.benefitPlan": "Program",
   "project": {
+    "picker": {
+      "label": "Projects",
+      "placeholder": "Select projects..."
+    },
     "activityPicker": {
       "label": "Activity",
       "null": ""


### PR DESCRIPTION
# Description

Since the beneficiary table renders the work day columns dynamically depending on the value entered for the "Working Days" field on the project, when user enters a very very large number (say 10000) the page hangs. To address this edge case, cap the max working days with a configurable default, so the "Work Day X" columns can render with reasonable performance. 

Also remove download button from the Program > Projects list table header as it is not a supported feature.

# Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

![max_working_days](https://github.com/user-attachments/assets/c29520df-e0f1-40e5-890e-7d487876cc51)

## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
